### PR TITLE
Alloc optimizations

### DIFF
--- a/test/main.zig
+++ b/test/main.zig
@@ -212,13 +212,8 @@ fn parseVal(obj: std.json.ObjectMap) !Val {
             const int = try std.fmt.parseInt(u32, json_value.String, 10);
             return Val{ .ExternRef = int };
         }
-    } else if (strcmp("funcref", json_type.String)) {
-        if (strcmp("null", json_value.String)) {
-            return Val.nullRef(ValType.FuncRef);
-        } else {
-            const int = try std.fmt.parseInt(u32, json_value.String, 10);
-            return Val{ .FuncRef = .{ .index = int, .module_instance = null } };
-        }
+    } else if (strcmp("funcref", json_type.String) and strcmp("null", json_value.String)) {
+        return Val.nullRef(ValType.FuncRef);
     } else {
         print("Failed to parse value of type '{s}' with value '{s}'\n", .{ json_type.String, json_value.String });
     }

--- a/test/main.zig
+++ b/test/main.zig
@@ -1148,6 +1148,8 @@ pub fn main() !void {
         "utf8-invalid-encoding",
     };
 
+    var did_all_succeed: bool = true;
+
     for (all_suites) |suite| {
         if (opts.suite_filter_or_null) |filter| {
             if (strcmp(filter, suite) == false) {
@@ -1207,10 +1209,12 @@ pub fn main() !void {
         if (opts.force_wasm_regen_only == false) {
             logVerbose("Running test suite: {s}\n", .{suite});
 
-            const succeeded = try run(allocator, suite_path, &opts);
-            if (succeeded == false) {
-                std.os.exit(1);
-            }
+            var success: bool = try run(allocator, suite_path, &opts);
+            did_all_succeed = did_all_succeed and success;
         }
+    }
+
+    if (did_all_succeed == false) {
+        std.os.exit(1);
     }
 }


### PR DESCRIPTION
* Split stack into Val, Label, CallFrame stacks for better cache coherency, which also unlocks alloc optimizations
* Avoid allocations when pushing frames and returning from functions by reusing stack space
* Shrink base Val size to pack more of them into the cache