### PR TITLE
Add package manager files and expose bytebox module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *Build) void {
     var bench_fibonacci_step: *CompileStep = buildWasmLib(b, "bench/samples/fibonacci.zig", optimize);
     var bench_mandelbrot_step: *CompileStep = buildWasmLib(b, "bench/samples/mandelbrot.zig", optimize);
 
-    const bytebox_module: *Build.Module = b.createModule(.{
+    const bytebox_module: *Build.Module = b.addModule("bytebox", .{
         .source_file = Build.LazyPath.relative("src/core.zig"),
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+  .name = "bytebox",
+  .version = "0.0.1",
+  .dependencies = .{},
+}


### PR DESCRIPTION
I would love to use bytebox for a project I am starting. In order to utilize the zig package manager, we need to add a `build.zig.zon` file, as well as make the bytebox module public.