### PR TITLE
Allow pull requests to trigger ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
   tests:


### PR DESCRIPTION
I think this should solve what you were seeing the other day with my other pull request. This allows the action to be run for opened pull requests.