### PR TITLE
Update to 0.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: "true"
+          submodules: 'true'
 
       - uses: goto-bus-stop/setup-zig@v2
         with:
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.11'
           cache: pip
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run mem64 test
         run: |
-          zig build -Doptimize=ReleaseSafe test-mem64
+          zig build test-mem64
 
       - name: Run wasi testsuite
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: "true"
 
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.11.0
+          version: 0.12.0
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
           cache: pip
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches:
       - main
@@ -40,7 +40,7 @@ jobs:
         run: python3 -m pip install -r requirements.txt
 
       # Ideally we would use this but it seems to be broken
-      # - name: Setup wasm-tools 
+      # - name: Setup wasm-tools
       #   uses: jcbhmr/setup-wasm-tools@v2
       #   with:
       #     wasm-tools-version: 1.207
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run mem64 test
         run: |
-          zig build test-mem64
+          zig build -Doptimize=ReleaseSafe test-mem64
 
       - name: Run wasi testsuite
         run: |

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 <a href=https://webassembly.org/><img src="https://avatars.githubusercontent.com/u/11578470?s=200&v=4" alt="Markdown Logo" width="150"/></a>
 
 Bytebox is a Webassembly VM.
+
 </div>
 
 ## Getting started
 
 ### Requirements
-Bytebox currently builds with [Zig 0.11.x](https://ziglang.org/download) to avoid churn on zig master.
+
+Bytebox currently builds with [Zig 0.12.x](https://ziglang.org/download) to avoid churn on zig master.
 
 ### Run
 
@@ -24,6 +26,7 @@ python3 test/wasi/wasi-testsuite/test-runner/wasi_test_runner.py -r test/wasi/by
 ### Usage
 
 You can use the standalone runtime to load and execute WebAssembly programs:
+
 ```sh
 zig build run -- <file> [function] [function args]...
 ```
@@ -75,88 +78,92 @@ Inter-language FFI is also supported. See `src/bytebox.h` for an overview in C. 
 
 This project is still in the alpha stage.
 
-| Legend | Meaning |
-| --- | --- |
-|✅|Implemented|
-|❌|TODO|
-|💀|Not planned/Removed from spec|
+| Legend | Meaning                       |
+| ------ | ----------------------------- |
+| ✅     | Implemented                   |
+| ❌     | TODO                          |
+| 💀     | Not planned/Removed from spec |
 
 ### [WebAssembly](https://webassembly.github.io/spec/core/index.html) support:
 
-| Status | Feature |
-| --- | --- |
-|✅|WebAssembly 1.0|
-|✅|Sign extension instructions|
-|✅|Non-trapping float-to-int conversion|
-|✅|Multiple values|
-|✅|Reference types|
-|✅|Table instructions|
-|✅|Multiple tables|
-|✅|Bulk memory and table instructions|
-|✅|Vector instructions|
+| Status | Feature                              |
+| ------ | ------------------------------------ |
+| ✅     | WebAssembly 1.0                      |
+| ✅     | Sign extension instructions          |
+| ✅     | Non-trapping float-to-int conversion |
+| ✅     | Multiple values                      |
+| ✅     | Reference types                      |
+| ✅     | Table instructions                   |
+| ✅     | Multiple tables                      |
+| ✅     | Bulk memory and table instructions   |
+| ✅     | Vector instructions                  |
 
 ### [WASI Preview 1](https://github.com/WebAssembly/WASI/tree/main) support:
 
-| Status | Feature |
-| --- | --- |
-|✅|args_get|
-|✅|args_sizes_get|
-|✅|environ_get|
-|✅|environ_sizes_get|
-|✅|clock_res_get|
-|✅|clock_time_get|
-|✅|fd_advise|
-|✅|fd_allocate|
-|✅|fd_close|
-|✅|fd_datasync|
-|✅|fd_fdstat_get|
-|✅|fd_fdstat_set_flags|
-|💀|fd_fdstat_set_rights|
-|✅|fd_filestat_get|
-|✅|fd_filestat_set_size|
-|✅|fd_filestat_set_times|
-|✅|fd_pread|
-|✅|fd_prestat_get|
-|✅|fd_prestat_dir_name|
-|✅|fd_pwrite|
-|✅|fd_read|
-|✅|fd_readdir|
-|✅|fd_renumber|
-|✅|fd_seek|
-|❌|fd_sync|
-|✅|fd_tell|
-|✅|fd_write|
-|✅|path_create_directory|
-|✅|path_filestat_get|
-|✅|path_filestat_set_times|
-|❌|path_link|
-|✅|path_open|
-|❌|path_readlink|
-|✅|path_remove_directory|
-|❌|path_rename|
-|✅|path_symlink|
-|✅|path_unlink_file|
-|❌|poll_oneoff|
-|✅|proc_exit|
-|💀|proc_raise|
-|❌|sched_yield|
-|✅|random_get|
-|❌|sock_accept|
-|❌|sock_recv|
-|❌|sock_send|
-|❌|sock_shutdown|
+| Status | Feature                 |
+| ------ | ----------------------- |
+| ✅     | args_get                |
+| ✅     | args_sizes_get          |
+| ✅     | environ_get             |
+| ✅     | environ_sizes_get       |
+| ✅     | clock_res_get           |
+| ✅     | clock_time_get          |
+| ✅     | fd_advise               |
+| ✅     | fd_allocate             |
+| ✅     | fd_close                |
+| ✅     | fd_datasync             |
+| ✅     | fd_fdstat_get           |
+| ✅     | fd_fdstat_set_flags     |
+| 💀     | fd_fdstat_set_rights    |
+| ✅     | fd_filestat_get         |
+| ✅     | fd_filestat_set_size    |
+| ✅     | fd_filestat_set_times   |
+| ✅     | fd_pread                |
+| ✅     | fd_prestat_get          |
+| ✅     | fd_prestat_dir_name     |
+| ✅     | fd_pwrite               |
+| ✅     | fd_read                 |
+| ✅     | fd_readdir              |
+| ✅     | fd_renumber             |
+| ✅     | fd_seek                 |
+| ❌     | fd_sync                 |
+| ✅     | fd_tell                 |
+| ✅     | fd_write                |
+| ✅     | path_create_directory   |
+| ✅     | path_filestat_get       |
+| ✅     | path_filestat_set_times |
+| ❌     | path_link               |
+| ✅     | path_open               |
+| ❌     | path_readlink           |
+| ✅     | path_remove_directory   |
+| ❌     | path_rename             |
+| ✅     | path_symlink            |
+| ✅     | path_unlink_file        |
+| ❌     | poll_oneoff             |
+| ✅     | proc_exit               |
+| 💀     | proc_raise              |
+| ❌     | sched_yield             |
+| ✅     | random_get              |
+| ❌     | sock_accept             |
+| ❌     | sock_recv               |
+| ❌     | sock_send               |
+| ❌     | sock_shutdown           |
 
 ### Roadmap
+
 These tasks must be completed to enter alpha:
-* API ergonomics pass
-* Documentation
-* General TODO/code cleanup
-* Crash hardening/fuzzing
+
+- API ergonomics pass
+- Documentation
+- General TODO/code cleanup
+- Crash hardening/fuzzing
 
 To enter beta:
-* No breaking API changes after this point
-* Performance competitive with other well-known interpreters (e.g. [micro-wasm-runtime](https://github.com/bytecodealliance/wasm-micro-runtime), [wasm3](https://github.com/wasm3/wasm3))
+
+- No breaking API changes after this point
+- Performance competitive with other well-known interpreters (e.g. [micro-wasm-runtime](https://github.com/bytecodealliance/wasm-micro-runtime), [wasm3](https://github.com/wasm3/wasm3))
 
 To have a 1.0 release:
-* Tested with a wide variety of wasm programs
-* Successfully used in other beta-quality projects
+
+- Tested with a wide variety of wasm programs
+- Successfully used in other beta-quality projects

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <a href=https://webassembly.org/><img src="https://avatars.githubusercontent.com/u/11578470?s=200&v=4" alt="Markdown Logo" width="150"/></a>
 
 Bytebox is a Webassembly VM.
-
 </div>
 
 ## Getting started
@@ -84,7 +83,7 @@ This project is still in the alpha stage.
 
 ### [WebAssembly](https://webassembly.github.io/spec/core/index.html) support:
 
-| Status | Feature|
+| Status | Feature |
 | --- | --- |
 |✅|WebAssembly 1.0|
 |✅|Sign extension instructions|
@@ -98,7 +97,7 @@ This project is still in the alpha stage.
 
 ### [WASI Preview 1](https://github.com/WebAssembly/WASI/tree/main) support:
 
-| Status | Feature|
+| Status | Feature |
 | --- | --- |
 |✅|args_get|
 |✅|args_sizes_get|
@@ -149,7 +148,6 @@ This project is still in the alpha stage.
 
 ### Roadmap
 These tasks must be completed to enter alpha:
-
 * API ergonomics pass
 * Documentation
 * General TODO/code cleanup

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Bytebox is a Webassembly VM.
 ## Getting started
 
 ### Requirements
-
 Bytebox currently builds with [Zig 0.12.x](https://ziglang.org/download) to avoid churn on zig master.
 
 ### Run
@@ -26,7 +25,6 @@ python3 test/wasi/wasi-testsuite/test-runner/wasi_test_runner.py -r test/wasi/by
 ### Usage
 
 You can use the standalone runtime to load and execute WebAssembly programs:
-
 ```sh
 zig build run -- <file> [function] [function args]...
 ```
@@ -78,92 +76,89 @@ Inter-language FFI is also supported. See `src/bytebox.h` for an overview in C. 
 
 This project is still in the alpha stage.
 
-| Legend | Meaning                       |
-| ------ | ----------------------------- |
-| ✅     | Implemented                   |
-| ❌     | TODO                          |
-| 💀     | Not planned/Removed from spec |
+| Legend | Meaning |
+| --- | --- |
+|✅|Implemented|
+|❌|TODO|
+|💀|Not planned/Removed from spec|
 
 ### [WebAssembly](https://webassembly.github.io/spec/core/index.html) support:
 
-| Status | Feature                              |
-| ------ | ------------------------------------ |
-| ✅     | WebAssembly 1.0                      |
-| ✅     | Sign extension instructions          |
-| ✅     | Non-trapping float-to-int conversion |
-| ✅     | Multiple values                      |
-| ✅     | Reference types                      |
-| ✅     | Table instructions                   |
-| ✅     | Multiple tables                      |
-| ✅     | Bulk memory and table instructions   |
-| ✅     | Vector instructions                  |
+| Status | Feature|
+| --- | --- |
+|✅|WebAssembly 1.0|
+|✅|Sign extension instructions|
+|✅|Non-trapping float-to-int conversion|
+|✅|Multiple values|
+|✅|Reference types|
+|✅|Table instructions|
+|✅|Multiple tables|
+|✅|Bulk memory and table instructions|
+|✅|Vector instructions|
 
 ### [WASI Preview 1](https://github.com/WebAssembly/WASI/tree/main) support:
 
-| Status | Feature                 |
-| ------ | ----------------------- |
-| ✅     | args_get                |
-| ✅     | args_sizes_get          |
-| ✅     | environ_get             |
-| ✅     | environ_sizes_get       |
-| ✅     | clock_res_get           |
-| ✅     | clock_time_get          |
-| ✅     | fd_advise               |
-| ✅     | fd_allocate             |
-| ✅     | fd_close                |
-| ✅     | fd_datasync             |
-| ✅     | fd_fdstat_get           |
-| ✅     | fd_fdstat_set_flags     |
-| 💀     | fd_fdstat_set_rights    |
-| ✅     | fd_filestat_get         |
-| ✅     | fd_filestat_set_size    |
-| ✅     | fd_filestat_set_times   |
-| ✅     | fd_pread                |
-| ✅     | fd_prestat_get          |
-| ✅     | fd_prestat_dir_name     |
-| ✅     | fd_pwrite               |
-| ✅     | fd_read                 |
-| ✅     | fd_readdir              |
-| ✅     | fd_renumber             |
-| ✅     | fd_seek                 |
-| ❌     | fd_sync                 |
-| ✅     | fd_tell                 |
-| ✅     | fd_write                |
-| ✅     | path_create_directory   |
-| ✅     | path_filestat_get       |
-| ✅     | path_filestat_set_times |
-| ❌     | path_link               |
-| ✅     | path_open               |
-| ❌     | path_readlink           |
-| ✅     | path_remove_directory   |
-| ❌     | path_rename             |
-| ✅     | path_symlink            |
-| ✅     | path_unlink_file        |
-| ❌     | poll_oneoff             |
-| ✅     | proc_exit               |
-| 💀     | proc_raise              |
-| ❌     | sched_yield             |
-| ✅     | random_get              |
-| ❌     | sock_accept             |
-| ❌     | sock_recv               |
-| ❌     | sock_send               |
-| ❌     | sock_shutdown           |
+| Status | Feature|
+| --- | --- |
+|✅|args_get|
+|✅|args_sizes_get|
+|✅|environ_get|
+|✅|environ_sizes_get|
+|✅|clock_res_get|
+|✅|clock_time_get|
+|✅|fd_advise|
+|✅|fd_allocate|
+|✅|fd_close|
+|✅|fd_datasync|
+|✅|fd_fdstat_get|
+|✅|fd_fdstat_set_flags|
+|💀|fd_fdstat_set_rights|
+|✅|fd_filestat_get|
+|✅|fd_filestat_set_size|
+|✅|fd_filestat_set_times|
+|✅|fd_pread|
+|✅|fd_prestat_get|
+|✅|fd_prestat_dir_name|
+|✅|fd_pwrite|
+|✅|fd_read|
+|✅|fd_readdir|
+|✅|fd_renumber|
+|✅|fd_seek|
+|❌|fd_sync|
+|✅|fd_tell|
+|✅|fd_write|
+|✅|path_create_directory|
+|✅|path_filestat_get|
+|✅|path_filestat_set_times|
+|❌|path_link|
+|✅|path_open|
+|❌|path_readlink|
+|✅|path_remove_directory|
+|❌|path_rename|
+|✅|path_symlink|
+|✅|path_unlink_file|
+|❌|poll_oneoff|
+|✅|proc_exit|
+|💀|proc_raise|
+|❌|sched_yield|
+|✅|random_get|
+|❌|sock_accept|
+|❌|sock_recv|
+|❌|sock_send|
+|❌|sock_shutdown|
 
 ### Roadmap
-
 These tasks must be completed to enter alpha:
 
-- API ergonomics pass
-- Documentation
-- General TODO/code cleanup
-- Crash hardening/fuzzing
+* API ergonomics pass
+* Documentation
+* General TODO/code cleanup
+* Crash hardening/fuzzing
 
 To enter beta:
-
-- No breaking API changes after this point
-- Performance competitive with other well-known interpreters (e.g. [micro-wasm-runtime](https://github.com/bytecodealliance/wasm-micro-runtime), [wasm3](https://github.com/wasm3/wasm3))
+* No breaking API changes after this point
+* Performance competitive with other well-known interpreters (e.g. [micro-wasm-runtime](https://github.com/bytecodealliance/wasm-micro-runtime), [wasm3](https://github.com/wasm3/wasm3))
 
 To have a 1.0 release:
-
-- Tested with a wide variety of wasm programs
-- Successfully used in other beta-quality projects
+* Tested with a wide variety of wasm programs
+* Successfully used in other beta-quality projects

--- a/bench/main.zig
+++ b/bench/main.zig
@@ -10,14 +10,14 @@ const Benchmark = struct {
 };
 
 fn elapsedMilliseconds(timer: *std.time.Timer) f64 {
-    var ns_elapsed: f64 = @as(f64, @floatFromInt(timer.read()));
+    const ns_elapsed: f64 = @as(f64, @floatFromInt(timer.read()));
     const ms_elapsed = ns_elapsed / 1000000.0;
     return ms_elapsed;
 }
 
 fn run(allocator: std.mem.Allocator, benchmark: Benchmark) !void {
     var cwd = std.fs.cwd();
-    var wasm_data: []u8 = try cwd.readFileAlloc(allocator, benchmark.filename, 1024 * 64); // Our wasm programs aren't very large
+    const wasm_data: []u8 = try cwd.readFileAlloc(allocator, benchmark.filename, 1024 * 64); // Our wasm programs aren't very large
 
     var timer = try Timer.start();
 
@@ -40,7 +40,7 @@ fn run(allocator: std.mem.Allocator, benchmark: Benchmark) !void {
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    var allocator: std.mem.Allocator = gpa.allocator();
+    const allocator: std.mem.Allocator = gpa.allocator();
 
     const benchmarks = [_]Benchmark{ .{
         .name = "add-one",

--- a/bench/main.zig
+++ b/bench/main.zig
@@ -3,6 +3,10 @@ const bytebox = @import("bytebox");
 const Val = bytebox.Val;
 const Timer = std.time.Timer;
 
+pub const std_options: std.Options = .{
+    .log_level = .info,
+};
+
 const Benchmark = struct {
     name: []const u8,
     filename: []const u8,
@@ -44,15 +48,15 @@ pub fn main() !void {
 
     const benchmarks = [_]Benchmark{ .{
         .name = "add-one",
-        .filename = "zig-out/lib/add-one.wasm",
+        .filename = "zig-out/bin/add-one.wasm",
         .param = 123456789,
     }, .{
         .name = "fibonacci",
-        .filename = "zig-out/lib/fibonacci.wasm",
+        .filename = "zig-out/bin/fibonacci.wasm",
         .param = 20,
     }, .{
         .name = "mandelbrot",
-        .filename = "zig-out/lib/mandelbrot.wasm",
+        .filename = "zig-out/bin/mandelbrot.wasm",
         .param = 20,
     } };
 

--- a/bench/samples/fibonacci.zig
+++ b/bench/samples/fibonacci.zig
@@ -2,8 +2,8 @@ export fn run(n: i32) i32 {
     if (n < 2) {
         return 1;
     } else {
-        var a = run(n - 1);
-        var b = run(n - 2);
+        const a = run(n - 1);
+        const b = run(n - 2);
         return a + b;
     }
 }

--- a/build.zig
+++ b/build.zig
@@ -98,7 +98,7 @@ pub fn build(b: *Build) void {
         compile_memtest.addArg("-Wl,--export-dynamic");
         compile_memtest.addArg("-o");
         compile_memtest.addArg("test/mem64/memtest.wasm");
-        compile_memtest.addFileArg(.{ .path = "test/mem64/memtest.c" });
+        compile_memtest.addFileArg(b.path("test/mem64/memtest.c"));
         compile_memtest.has_side_effects = true;
 
         b.getInstallStep().dependOn(&compile_memtest.step);

--- a/build.zig
+++ b/build.zig
@@ -23,7 +23,7 @@ pub fn build(b: *Build) void {
     var bench_fibonacci_step: *CompileStep = buildWasmExe(b, "bench/samples/fibonacci.zig", optimize);
     var bench_mandelbrot_step: *CompileStep = buildWasmExe(b, "bench/samples/mandelbrot.zig", optimize);
 
-    const bytebox_module: *Build.Module = b.addModule(.{
+    const bytebox_module: *Build.Module = b.addModule("bytebox", .{
         .root_source_file = b.path("src/core.zig"),
     });
 

--- a/build.zig
+++ b/build.zig
@@ -123,7 +123,7 @@ fn buildWasmLib(b: *Build, filepath: []const u8, optimize: std.builtin.Mode) *Co
     var filename: []const u8 = std.fs.path.basename(filepath);
     const filename_no_extension: []const u8 = filename[0 .. filename.len - 4];
 
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = filename_no_extension,
         .root_source_file = b.path(filepath),
         .target = b.resolveTargetQuery(.{
@@ -132,6 +132,7 @@ fn buildWasmLib(b: *Build, filepath: []const u8, optimize: std.builtin.Mode) *Co
         }),
         .optimize = optimize,
     });
+    lib.entry = .disabled;
 
     // const mode = b.standardOptimizeOption();
     // lib.setBuildMode(mode);

--- a/build.zig
+++ b/build.zig
@@ -19,9 +19,9 @@ pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    var bench_add_one_step: *CompileStep = buildWasmLib(b, "bench/samples/add-one.zig", optimize);
-    var bench_fibonacci_step: *CompileStep = buildWasmLib(b, "bench/samples/fibonacci.zig", optimize);
-    var bench_mandelbrot_step: *CompileStep = buildWasmLib(b, "bench/samples/mandelbrot.zig", optimize);
+    var bench_add_one_step: *CompileStep = buildWasmExe(b, "bench/samples/add-one.zig", optimize);
+    var bench_fibonacci_step: *CompileStep = buildWasmExe(b, "bench/samples/fibonacci.zig", optimize);
+    var bench_mandelbrot_step: *CompileStep = buildWasmExe(b, "bench/samples/mandelbrot.zig", optimize);
 
     const bytebox_module: *Build.Module = b.addModule(.{
         .root_source_file = b.path("src/core.zig"),
@@ -119,11 +119,11 @@ fn buildExeWithRunStep(b: *Build, target: Build.ResolvedTarget, optimize: std.bu
     return step;
 }
 
-fn buildWasmLib(b: *Build, filepath: []const u8, optimize: std.builtin.Mode) *CompileStep {
+fn buildWasmExe(b: *Build, filepath: []const u8, optimize: std.builtin.Mode) *CompileStep {
     var filename: []const u8 = std.fs.path.basename(filepath);
     const filename_no_extension: []const u8 = filename[0 .. filename.len - 4];
 
-    const lib = b.addExecutable(.{
+    const exe = b.addExecutable(.{
         .name = filename_no_extension,
         .root_source_file = b.path(filepath),
         .target = b.resolveTargetQuery(.{
@@ -132,11 +132,12 @@ fn buildWasmLib(b: *Build, filepath: []const u8, optimize: std.builtin.Mode) *Co
         }),
         .optimize = optimize,
     });
-    lib.entry = .disabled;
+    exe.rdynamic = true;
+    exe.entry = .disabled;
 
     // const mode = b.standardOptimizeOption();
     // lib.setBuildMode(mode);
-    b.installArtifact(lib);
+    b.installArtifact(exe);
 
-    return lib;
+    return exe;
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,16 @@
 .{
-  .name = "bytebox",
-  .version = "0.0.1",
-  .dependencies = .{},
+    .name = "bytebox",
+    .version = "0.0.1",
+    .minimum_zig_version = "0.12.0",
+    .paths = .{
+        "src",
+        "test/main.zig",
+        "bench",
+        "run",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
+    .dependencies = .{},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,10 @@
     .minimum_zig_version = "0.12.0",
     .paths = .{
         "src",
-        "test/main.zig",
+        "test/mem64",
+        "test/wasi/run.py",
+        "test/wasi/bytebox_adapter.py",
+        "test/wasm/main.zig",
         "bench",
         "run",
         "build.zig",

--- a/run/main.zig
+++ b/run/main.zig
@@ -51,13 +51,13 @@ fn parseCmdOpts(args: [][]const u8, env_buffer: *std.ArrayList([]const u8), dir_
 
     var arg_index: usize = 1;
     while (arg_index < args.len) {
-        var arg = args[arg_index];
+        const arg = args[arg_index];
 
         if (arg_index == 1 and !isArgvOption(arg)) {
             opts.filename = arg;
             opts.wasm_argv = args[1..2];
         } else if (arg_index == 2 and !isArgvOption(arg)) {
-            var wasm_argv_begin: usize = arg_index - 1; // include wasm filename
+            const wasm_argv_begin: usize = arg_index - 1; // include wasm filename
             var wasm_argv_end: usize = arg_index;
             while (wasm_argv_end + 1 < args.len and !isArgvOption(args[wasm_argv_end + 1])) {
                 wasm_argv_end += 1;
@@ -138,7 +138,7 @@ const version_string = "bytebox v0.0.1";
 fn printHelp(args: [][]const u8) !void {
     const usage_string: []const u8 =
         \\Usage: {s} <FILE> [WASM_ARGS]... [OPTION]...
-        \\  
+        \\
         \\  Options:
         \\
         \\    -h, --help
@@ -150,7 +150,7 @@ fn printHelp(args: [][]const u8) !void {
         \\    --dump
         \\      Prints the given module definition's imports and exports. Imports are qualified
         \\      with the import module name.
-        \\    
+        \\
         \\    -i, --invoke <FUNCTION> [ARGS]...
         \\      Call an exported, named function with arguments. The arguments are automatically
         \\      translated from string inputs to the function's native types. If the conversion
@@ -183,7 +183,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator: std.mem.Allocator = gpa.allocator();
 
-    var args = try std.process.argsAlloc(allocator);
+    const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
     var env_buffer = std.ArrayList([]const u8).init(allocator);
@@ -228,7 +228,7 @@ pub fn main() !void {
     std.debug.assert(opts.filename != null);
 
     var cwd = std.fs.cwd();
-    var wasm_data: []u8 = cwd.readFileAlloc(allocator, opts.filename.?, 1024 * 1024 * 128) catch |e| {
+    const wasm_data: []u8 = cwd.readFileAlloc(allocator, opts.filename.?, 1024 * 1024 * 128) catch |e| {
         std.log.err("Failed to read file '{s}' into memory: {}", .{ opts.filename.?, e });
         return RunErrors.IoError;
     };
@@ -263,7 +263,7 @@ pub fn main() !void {
     }, allocator);
     defer wasi.deinitImports(&imports_wasi);
 
-    var instantiate_opts = bytebox.ModuleInstantiateOpts{
+    const instantiate_opts = bytebox.ModuleInstantiateOpts{
         .imports = &[_]bytebox.ModuleImportPackage{imports_wasi},
     };
 
@@ -308,28 +308,28 @@ pub fn main() !void {
         const arg: []const u8 = invoke_args[i];
         switch (valtype) {
             .I32 => {
-                var parsed: i32 = std.fmt.parseInt(i32, arg, 0) catch |e| {
+                const parsed: i32 = std.fmt.parseInt(i32, arg, 0) catch |e| {
                     std.log.err("Failed to parse arg at index {} ('{s}') as an i32: {}", .{ i, arg, e });
                     return RunErrors.BadFunctionParam;
                 };
                 params.items[i] = Val{ .I32 = parsed };
             },
             .I64 => {
-                var parsed: i64 = std.fmt.parseInt(i64, arg, 0) catch |e| {
+                const parsed: i64 = std.fmt.parseInt(i64, arg, 0) catch |e| {
                     std.log.err("Failed to parse arg at index {} ('{s}') as an i64: {}", .{ i, arg, e });
                     return RunErrors.BadFunctionParam;
                 };
                 params.items[i] = Val{ .I64 = parsed };
             },
             .F32 => {
-                var parsed: f32 = std.fmt.parseFloat(f32, arg) catch |e| {
+                const parsed: f32 = std.fmt.parseFloat(f32, arg) catch |e| {
                     std.log.err("Failed to parse arg at index {} ('{s}') as a f32: {}", .{ i, arg, e });
                     return RunErrors.BadFunctionParam;
                 };
                 params.items[i] = Val{ .F32 = parsed };
             },
             .F64 => {
-                var parsed: f64 = std.fmt.parseFloat(f64, arg) catch |e| {
+                const parsed: f64 = std.fmt.parseFloat(f64, arg) catch |e| {
                     std.log.err("Failed to parse arg at index {} ('{s}') as a f64: {}", .{ i, arg, e });
                     return RunErrors.BadFunctionParam;
                 };
@@ -363,7 +363,7 @@ pub fn main() !void {
     {
         var strbuf = std.ArrayList(u8).init(allocator);
         defer strbuf.deinit();
-        var writer = strbuf.writer();
+        const writer = strbuf.writer();
 
         if (returns.items.len > 0) {
             const return_types = func_export.returns;
@@ -388,13 +388,13 @@ pub fn main() !void {
 }
 
 fn writeSignature(strbuf: *std.ArrayList(u8), info: *const bytebox.FunctionExport) !void {
-    var writer = strbuf.writer();
+    const writer = strbuf.writer();
     if (info.params.len == 0) {
         try std.fmt.format(writer, "  params: none\n", .{});
     } else {
         try std.fmt.format(writer, "  params:\n", .{});
         for (info.params) |valtype| {
-            var name: []const u8 = valtypeToString(valtype);
+            const name: []const u8 = valtypeToString(valtype);
             try std.fmt.format(writer, "    {s}\n", .{name});
         }
     }
@@ -404,7 +404,7 @@ fn writeSignature(strbuf: *std.ArrayList(u8), info: *const bytebox.FunctionExpor
     } else {
         try std.fmt.format(writer, "  returns:\n", .{});
         for (info.returns) |valtype| {
-            var name: []const u8 = valtypeToString(valtype);
+            const name: []const u8 = valtypeToString(valtype);
             try std.fmt.format(writer, "    {s}\n", .{name});
         }
     }

--- a/src/cffi.zig
+++ b/src/cffi.zig
@@ -599,16 +599,16 @@ comptime {
 
         // Default stack-probe functions emitted by LLVM
         if (is_mingw) {
-            @export(_chkstk, .{ .name = "_alloca", .linkage = .Weak });
-            @export(___chkstk_ms, .{ .name = "___chkstk_ms", .linkage = .Weak });
+            @export(_chkstk, .{ .name = "_alloca", .linkage = .weak });
+            @export(___chkstk_ms, .{ .name = "___chkstk_ms", .linkage = .weak });
 
             if (builtin.cpu.arch.isAARCH64()) {
-                @export(__chkstk, .{ .name = "__chkstk", .linkage = .Weak });
+                @export(__chkstk, .{ .name = "__chkstk", .linkage = .weak });
             }
         } else if (!builtin.link_libc) {
             // This symbols are otherwise exported by MSVCRT.lib
-            @export(_chkstk, .{ .name = "_chkstk", .linkage = .Weak });
-            @export(__chkstk, .{ .name = "__chkstk", .linkage = .Weak });
+            @export(_chkstk, .{ .name = "_chkstk", .linkage = .weak });
+            @export(__chkstk, .{ .name = "__chkstk", .linkage = .weak });
         }
     }
 
@@ -616,7 +616,7 @@ comptime {
         .x86,
         .x86_64,
         => {
-            @export(zig_probe_stack, .{ .name = "__zig_probe_stack", .linkage = .Weak });
+            @export(zig_probe_stack, .{ .name = "__zig_probe_stack", .linkage = .weak });
         },
         else => {},
     }

--- a/src/cffi.zig
+++ b/src/cffi.zig
@@ -184,7 +184,7 @@ export fn bb_error_str(c_error: CError) [*:0]const u8 {
 }
 
 export fn bb_module_definition_create(c_opts: CModuleDefinitionInitOpts) ?*core.ModuleDefinition {
-    var allocator = cffi_gpa.allocator();
+    const allocator = cffi_gpa.allocator();
 
     const debug_name: []const u8 = if (c_opts.debug_name == null) "" else std.mem.sliceTo(c_opts.debug_name.?, 0);
     const opts_translated = core.ModuleDefinitionOpts{
@@ -310,7 +310,7 @@ export fn bb_import_package_add_memory(package: ?*ModuleImportPackage, config: ?
             unreachable;
         }
 
-        var mem_import = core.MemoryImport{
+        const mem_import = core.MemoryImport{
             .name = name,
             .data = .{ .Host = mem_instance },
         };
@@ -335,7 +335,7 @@ export fn bb_set_debug_trace_mode(c_mode: CDebugTraceMode) void {
 }
 
 export fn bb_module_instance_create(module_definition: ?*ModuleDefinition) ?*ModuleInstance {
-    var allocator = cffi_gpa.allocator();
+    const allocator = cffi_gpa.allocator();
 
     var module: ?*core.ModuleInstance = null;
 
@@ -361,7 +361,7 @@ export fn bb_module_instance_instantiate(module: ?*ModuleInstance, c_opts: CModu
     if (module != null and c_opts.packages != null and num_wasm_memory_callbacks != 1) {
         const packages: []?*const ModuleImportPackage = c_opts.packages.?[0..c_opts.num_packages];
 
-        var allocator = cffi_gpa.allocator();
+        const allocator = cffi_gpa.allocator();
         var flat_packages = std.ArrayList(ModuleImportPackage).init(allocator);
         defer flat_packages.deinit();
 
@@ -454,8 +454,8 @@ export fn bb_module_instance_invoke(module: ?*ModuleInstance, c_handle: CFuncHan
             .trap_on_start = opts.trap_on_start,
         };
 
-        var params_slice: []const Val = if (params != null) params.?[0..num_params] else &[_]Val{};
-        var returns_slice: []Val = if (returns != null) returns.?[0..num_returns] else &[_]Val{};
+        const params_slice: []const Val = if (params != null) params.?[0..num_params] else &[_]Val{};
+        const returns_slice: []Val = if (returns != null) returns.?[0..num_returns] else &[_]Val{};
 
         if (module.?.invoke(handle, params_slice.ptr, returns_slice.ptr, invoke_opts)) {
             return CError.Ok;
@@ -490,7 +490,7 @@ export fn bb_module_instance_debug_set_trap(module: ?*ModuleInstance, address: u
 
 export fn bb_module_instance_mem(module: ?*ModuleInstance, offset: usize, length: usize) ?*anyopaque {
     if (module != null and length > 0) {
-        var mem = module.?.memorySlice(offset, length);
+        const mem = module.?.memorySlice(offset, length);
         return if (mem.len > 0) mem.ptr else null;
     }
 
@@ -499,7 +499,7 @@ export fn bb_module_instance_mem(module: ?*ModuleInstance, offset: usize, length
 
 export fn bb_module_instance_mem_all(module: ?*ModuleInstance) CSlice {
     if (module != null) {
-        var mem = module.?.memoryAll();
+        const mem = module.?.memoryAll();
         return CSlice{
             .data = mem.ptr,
             .length = mem.len,

--- a/src/core.zig
+++ b/src/core.zig
@@ -64,7 +64,7 @@ pub const VmType = enum {
 };
 
 pub fn createModuleInstance(vm_type: VmType, module_def: *const ModuleDefinition, allocator: std.mem.Allocator) AllocError!*ModuleInstance {
-    var vm: *inst.VM = switch (vm_type) {
+    const vm: *inst.VM = switch (vm_type) {
         .Stack => try inst.VM.create(vm_stack.StackVM, allocator),
         .Register => try inst.VM.create(vm_register.RegisterVM, allocator),
     };

--- a/src/definition.zig
+++ b/src/definition.zig
@@ -1196,7 +1196,7 @@ pub const Instruction = struct {
                 immediate = InstructionImmediates{ .ValueVec = try decodeVec(reader) };
             },
             .I8x16_Shuffle => {
-                const lane_indices: [16]u8 = undefined;
+                var lane_indices: [16]u8 = undefined;
                 for (&lane_indices) |*v| {
                     const laneidx: u8 = try reader.readByte();
                     v.* = laneidx;

--- a/src/definition.zig
+++ b/src/definition.zig
@@ -3347,6 +3347,10 @@ pub const ModuleDefinition = struct {
             item.elems_expr.deinit();
         }
 
+        for (self.datas.items) |*data| {
+            data.bytes.deinit();
+        }
+
         self.types.deinit();
         self.imports.functions.deinit();
         self.imports.tables.deinit();

--- a/src/definition.zig
+++ b/src/definition.zig
@@ -97,8 +97,8 @@ const k_block_type_void_sentinel_byte: u8 = 0x40;
 
 fn decodeFloat(comptime T: type, reader: anytype) !T {
     return switch (T) {
-        f32 => @as(f32, @bitCast(try reader.readIntLittle(u32))),
-        f64 => @as(f64, @bitCast(try reader.readIntLittle(u64))),
+        f32 => @as(f32, @bitCast(try reader.readInt(u32, .little))),
+        f64 => @as(f64, @bitCast(try reader.readInt(u64, .little))),
         else => unreachable,
     };
 }

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -1187,11 +1187,11 @@ pub const ModuleInstance = struct {
 
     pub fn memoryWriteInt(self: *ModuleInstance, comptime T: type, value: T, offset: usize) bool {
         var bytes: [(@typeInfo(T).Int.bits + 7) / 8]u8 = undefined;
-        std.mem.writeIntLittle(T, &bytes, value);
+        std.mem.writeInt(T, &bytes, value, .little);
 
-        var destination = self.memorySlice(offset, bytes.len);
+        const destination = self.memorySlice(offset, bytes.len);
         if (destination.len == bytes.len) {
-            std.mem.copy(u8, destination, &bytes);
+            @memcpy(destination, &bytes);
             return true;
         }
 

--- a/src/opcode.zig
+++ b/src/opcode.zig
@@ -915,14 +915,14 @@ pub const WasmOpcode = enum(u16) {
     }
 
     pub fn decode(reader: anytype) !WasmOpcode {
-        var byte = try reader.readByte();
+        const byte = try reader.readByte();
         var wasm_op: WasmOpcode = undefined;
         if (byte == 0xFC or byte == 0xFD) {
-            var type_opcode = try common.decodeLEB128(u32, reader);
+            const type_opcode = try common.decodeLEB128(u32, reader);
             if (type_opcode > std.math.maxInt(u8)) {
                 return error.MalformedIllegalOpcode;
             }
-            var byte2 = @as(u8, @intCast(type_opcode));
+            const byte2 = @as(u8, @intCast(type_opcode));
             var extended: u16 = byte;
             extended = extended << 8;
             extended |= byte2;

--- a/src/stringpool.zig
+++ b/src/stringpool.zig
@@ -44,10 +44,10 @@ pub fn put(self: *StringPool, str: []const u8) ![]const u8 {
     try self.lookup.put(hash, str_offset_begin);
 
     var bytes: []u8 = self.buffer.items[str_offset_begin..str_offset_end];
-    var str_len: *StringLenType = @alignCast(@ptrCast(bytes.ptr));
+    const str_len: *StringLenType = @alignCast(@ptrCast(bytes.ptr));
     str_len.* = @as(StringLenType, @intCast(str.len));
-    var str_bytes: []u8 = bytes[@sizeOf(StringLenType)..];
-    std.mem.copy(u8, str_bytes, str);
+    const str_bytes: []u8 = bytes[@sizeOf(StringLenType)..];
+    @memcpy(str_bytes, str);
 
     return str_bytes;
 }
@@ -57,8 +57,8 @@ pub fn find(self: *StringPool, str: []const u8) ?[]const u8 {
 
     if (self.lookup.get(hash)) |string_bytes_begin| {
         var str_bytes: [*]u8 = self.buffer.items[string_bytes_begin..].ptr;
-        var str_len: *StringLenType = @alignCast(@ptrCast(str_bytes));
-        var pooled_str: []u8 = str_bytes[@sizeOf(StringLenType) .. @sizeOf(StringLenType) + str_len.*];
+        const str_len: *StringLenType = @alignCast(@ptrCast(str_bytes));
+        const pooled_str: []u8 = str_bytes[@sizeOf(StringLenType) .. @sizeOf(StringLenType) + str_len.*];
         return pooled_str;
     }
 
@@ -114,7 +114,7 @@ test "basic" {
     try std.testing.expect(std.mem.eql(u8, test2_str_found.?, test2_str));
     try std.testing.expect(std.mem.eql(u8, long_str_found.?, long_str));
 
-    var lazyadd_str1 = try pool.findOrPut("lazy put");
-    var lazyadd_str2 = try pool.findOrPut("lazy put");
+    const lazyadd_str1 = try pool.findOrPut("lazy put");
+    const lazyadd_str2 = try pool.findOrPut("lazy put");
     try std.testing.expect(lazyadd_str1.ptr == lazyadd_str2.ptr);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -7,12 +7,12 @@ const Limits = core.Limits;
 const MemoryInstance = core.MemoryInstance;
 
 test "StackVM.Integration" {
-    const wasm_filepath = "zig-out/lib/mandelbrot.wasm";
+    const wasm_filepath = "zig-out/bin/mandelbrot.wasm";
 
     var allocator = std.testing.allocator;
 
     var cwd = std.fs.cwd();
-    var wasm_data: []u8 = try cwd.readFileAlloc(allocator, wasm_filepath, 1024 * 1024 * 128);
+    const wasm_data: []u8 = try cwd.readFileAlloc(allocator, wasm_filepath, 1024 * 1024 * 128);
     defer allocator.free(wasm_data);
 
     const module_def_opts = core.ModuleDefinitionOpts{
@@ -36,7 +36,7 @@ test "MemoryInstance.init" {
         var memory = MemoryInstance.init(limits, null);
         defer memory.deinit();
         try expectEqual(memory.limits.min, 0);
-        try expectEqual(memory.limits.max, MemoryInstance.k_max_pages);
+        try expectEqual(memory.limits.max.?, MemoryInstance.k_max_pages);
         try expectEqual(memory.size(), 0);
         try expectEqual(memory.mem.Internal.items.len, 0);
     }

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -1224,7 +1224,7 @@ const InstructionFuncs = struct {
             const vec = @as(T, @bitCast(stack.popV128()));
             var arr: [type_info.len]child_type = undefined;
             for (&arr, 0..) |*v, i| {
-                v.* = @as(child_type, @bitCast(std.math.absCast(vec[i])));
+                v.* = @as(child_type, @bitCast(@abs(vec[i])));
             }
             const abs: T = arr;
             stack.pushV128(@as(v128, @bitCast(abs)));
@@ -4978,7 +4978,7 @@ const InstructionFuncs = struct {
     fn op_F32x4_Abs(pc: u32, code: [*]const Instruction, stack: *Stack) anyerror!void {
         try debugPreamble("F32x4_Abs", pc, code, stack);
         const vec = @as(f32x4, @bitCast(stack.popV128()));
-        const abs = @fabs(vec);
+        const abs = @abs(vec);
         stack.pushV128(@as(v128, @bitCast(abs)));
         try @call(.always_tail, InstructionFuncs.lookup(code[pc + 1].opcode), .{ pc + 1, code, stack });
     }
@@ -5050,7 +5050,7 @@ const InstructionFuncs = struct {
     fn op_F64x2_Abs(pc: u32, code: [*]const Instruction, stack: *Stack) anyerror!void {
         try debugPreamble("F64x2_Abs", pc, code, stack);
         const vec = @as(f64x2, @bitCast(stack.popV128()));
-        const abs = @fabs(vec);
+        const abs = @abs(vec);
         stack.pushV128(@as(v128, @bitCast(abs)));
         try @call(.always_tail, InstructionFuncs.lookup(code[pc + 1].opcode), .{ pc + 1, code, stack });
     }

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -2533,8 +2533,7 @@ const InstructionFuncs = struct {
         try debugPreamble("I32_Rem_S", pc, code, stack);
         const v2: i32 = stack.popI32();
         const v1: i32 = stack.popI32();
-        const denom = @abs(v2);
-        const value = std.math.rem(i32, v1, denom) catch |e| {
+        const value = std.math.rem(i32, v1, v2) catch |e| {
             if (e == error.DivisionByZero) {
                 return error.TrapIntegerDivisionByZero;
             } else {
@@ -2726,8 +2725,7 @@ const InstructionFuncs = struct {
         try debugPreamble("I64_Rem_S", pc, code, stack);
         const v2: i64 = stack.popI64();
         const v1: i64 = stack.popI64();
-        const denom = @abs(v2);
-        const value = std.math.rem(i64, v1, denom) catch |e| {
+        const value = std.math.rem(i64, v1, v2) catch |e| {
             if (e == error.DivisionByZero) {
                 return error.TrapIntegerDivisionByZero;
             } else {

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -854,6 +854,7 @@ const InstructionFuncs = struct {
     };
 
     fn run(pc: u32, code: [*]const Instruction, stack: *Stack) anyerror!void {
+        std.debug.print("Running code {any}\n", .{code[pc]});
         try @call(.always_tail, InstructionFuncs.lookup(code[pc].opcode), .{ pc, code, stack });
     }
 
@@ -2100,6 +2101,8 @@ const InstructionFuncs = struct {
             .I64 => stack.popI64(),
             else => unreachable,
         };
+
+        std.debug.print("Growing from {} to {}", .{ old_num_pages, num_pages });
 
         if (num_pages >= 0 and memory_instance.grow(@as(usize, @intCast(num_pages)))) {
             stack.pushI32(old_num_pages);

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -854,7 +854,6 @@ const InstructionFuncs = struct {
     };
 
     fn run(pc: u32, code: [*]const Instruction, stack: *Stack) anyerror!void {
-        std.debug.print("Running code {any}\n", .{code[pc]});
         try @call(.always_tail, InstructionFuncs.lookup(code[pc].opcode), .{ pc, code, stack });
     }
 
@@ -2101,8 +2100,6 @@ const InstructionFuncs = struct {
             .I64 => stack.popI64(),
             else => unreachable,
         };
-
-        std.debug.print("Growing from {} to {}", .{ old_num_pages, num_pages });
 
         if (num_pages >= 0 and memory_instance.grow(@as(usize, @intCast(num_pages)))) {
             stack.pushI32(old_num_pages);

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -2102,7 +2102,11 @@ const InstructionFuncs = struct {
         };
 
         if (num_pages >= 0 and memory_instance.grow(@as(usize, @intCast(num_pages)))) {
-            stack.pushI32(old_num_pages);
+            switch (memory_instance.limits.indexType()) {
+                .I32 => stack.pushI32(old_num_pages),
+                .I64 => stack.pushI64(old_num_pages),
+                else => unreachable,
+            }
             try @call(.always_tail, InstructionFuncs.lookup(code[pc + 1].opcode), .{ pc + 1, code, stack });
         } else {
             switch (memory_instance.limits.indexType()) {

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -1886,7 +1886,7 @@ fn fd_wasi_prestat_dir_name(userdata: ?*anyopaque, module: *ModuleInstance, para
         if (context.fdDirPath(fd_dir_wasi, &errno)) |path_source| {
             if (Helpers.getMemorySlice(module, path_mem_offset, path_mem_length, &errno)) |path_dest| {
                 if (path_source.len <= path_dest.len) {
-                    std.mem.copy(u8, path_dest, path_source);
+                    @memcpy(path_dest, path_source);
 
                     // add null terminator if there's room
                     if (path_dest.len > path_source.len) {

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -719,7 +719,7 @@ const Helpers = struct {
                 writeIntToMemory(u32, dest_string_strings, dest_string_ptrs, module, &errno);
 
                 if (getMemorySlice(module, dest_string_strings, string.len + 1, &errno)) |mem| {
-                    std.mem.copy(u8, mem[0..string.len], string);
+                    @memcpy(mem[0..string.len], string);
                     mem[string.len] = 0; // null terminator
 
                     dest_string_ptrs += @sizeOf(u32);

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -11,7 +11,7 @@ const ModuleImportPackage = core.ModuleImportPackage;
 
 const WasiContext = struct {
     const FdInfo = struct {
-        fd: std.os.fd_t,
+        fd: std.posix.fd_t,
         path_absolute: []const u8,
         rights: WasiRights,
         is_preopen: bool,
@@ -263,7 +263,7 @@ const WasiContext = struct {
         return null;
     }
 
-    fn fdUpdate(self: *WasiContext, fd_wasi: u32, new_fd: std.os.fd_t) void {
+    fn fdUpdate(self: *WasiContext, fd_wasi: u32, new_fd: std.posix.fd_t) void {
         if (self.fd_wasi_table.get(fd_wasi)) |fd_table_index| {
             self.fd_table.items[fd_table_index].fd = new_fd;
         } else {
@@ -314,7 +314,7 @@ const WasiContext = struct {
 
             fd_info.open_handles -= 1;
             if (fd_info.open_handles == 0) {
-                std.os.close(fd_info.fd);
+                std.posix.close(fd_info.fd);
                 self.fd_table_freelist.appendAssumeCapacity(fd_table_index); // capacity was allocated when the associated fd_table slot was allocated
             }
         } else {
@@ -335,7 +335,7 @@ const WasiContext = struct {
             _ = self.fd_path_lookup.remove(path_absolute);
 
             var fd_info: *FdInfo = &self.fd_table.items[fd_table_index];
-            std.os.close(fd_info.fd);
+            std.posix.close(fd_info.fd);
             fd_info.open_handles = 0;
             self.fd_table_freelist.appendAssumeCapacity(fd_table_index); // capacity was allocated when the associated fd_table slot was allocated
         }
@@ -731,20 +731,17 @@ const Helpers = struct {
         returns[0] = Val{ .I32 = @intFromEnum(errno) };
     }
 
-    fn convertClockId(wasi_clockid: i32, errno: *Errno) i32 {
-        return switch (wasi_clockid) {
-            std.os.wasi.CLOCK.REALTIME => if (builtin.os.tag != .windows) std.os.system.CLOCK.REALTIME else WindowsApi.CLOCK.REALTIME,
-            std.os.wasi.CLOCK.MONOTONIC => if (builtin.os.tag != .windows) std.os.system.CLOCK.MONOTONIC else WindowsApi.CLOCK.MONOTONIC,
-            std.os.wasi.CLOCK.PROCESS_CPUTIME_ID => if (builtin.os.tag != .windows) std.os.system.CLOCK.PROCESS_CPUTIME_ID else WindowsApi.CLOCK.PROCESS_CPUTIME_ID,
-            std.os.wasi.CLOCK.THREAD_CPUTIME_ID => if (builtin.os.tag != .windows) std.os.system.CLOCK.THREAD_CPUTIME_ID else WindowsApi.CLOCK.THREAD_CPUTIME_ID,
-            else => {
-                errno.* = Errno.INVAL;
-                return 0;
-            },
+    fn convertClockId(wasi_clockid: i32) i32 {
+        const clockid_t: std.os.wasi.clockid_t = @enumFromInt(wasi_clockid);
+        return switch (clockid_t) {
+            std.os.wasi.clockid_t.REALTIME => if (builtin.os.tag != .windows) std.posix.CLOCK.REALTIME else WindowsApi.CLOCK.REALTIME,
+            std.os.wasi.clockid_t.MONOTONIC => if (builtin.os.tag != .windows) std.posix.CLOCK.MONOTONIC else WindowsApi.CLOCK.MONOTONIC,
+            std.os.wasi.clockid_t.PROCESS_CPUTIME_ID => if (builtin.os.tag != .windows) std.posix.CLOCK.PROCESS_CPUTIME_ID else WindowsApi.CLOCK.PROCESS_CPUTIME_ID,
+            std.os.wasi.clockid_t.THREAD_CPUTIME_ID => if (builtin.os.tag != .windows) std.posix.CLOCK.THREAD_CPUTIME_ID else WindowsApi.CLOCK.THREAD_CPUTIME_ID,
         };
     }
 
-    fn posixTimespecToWasi(ts: std.os.system.timespec) std.os.wasi.timestamp_t {
+    fn posixTimespecToWasi(ts: std.posix.timespec) std.os.wasi.timestamp_t {
         const ns_per_second = 1000000000;
         const sec_part = @as(u64, @intCast(ts.tv_sec));
         const nsec_part = @as(u64, @intCast(ts.tv_nsec));
@@ -834,23 +831,23 @@ const Helpers = struct {
         };
     }
 
-    fn fdflagsToFlagsPosix(fdflags: WasiFdFlags) u32 {
-        var flags: u32 = 0;
+    fn fdflagsToFlagsPosix(fdflags: WasiFdFlags) std.posix.O {
+        var flags: std.posix.O = .{};
 
         if (fdflags.append) {
-            flags |= std.os.O.APPEND;
+            flags.APPEND = true;
         }
         if (fdflags.dsync) {
-            flags |= std.os.O.DSYNC;
+            flags.DSYNC = true;
         }
         if (fdflags.nonblock) {
-            flags |= std.os.O.NONBLOCK;
+            flags.NONBLOCK = true;
         }
-        if (builtin.os.tag != .macos and fdflags.rsync) {
-            flags |= std.os.O.RSYNC;
+        if (builtin.os.tag != .macos and builtin.os.tag != .linux and fdflags.rsync) {
+            flags.RSYNC = true;
         }
         if (fdflags.sync) {
-            flags |= std.os.O.SYNC;
+            flags.SYNC = true;
         }
 
         return flags;
@@ -866,16 +863,16 @@ const Helpers = struct {
         }
     }
 
-    fn posixModeToWasiFiletype(mode: std.os.mode_t) std.os.wasi.filetype_t {
-        if (std.os.S.ISREG(mode)) {
+    fn posixModeToWasiFiletype(mode: std.posix.mode_t) std.os.wasi.filetype_t {
+        if (std.posix.S.ISREG(mode)) {
             return .REGULAR_FILE;
-        } else if (std.os.S.ISDIR(mode)) {
+        } else if (std.posix.S.ISDIR(mode)) {
             return .DIRECTORY;
-        } else if (std.os.S.ISCHR(mode)) {
+        } else if (std.posix.S.ISCHR(mode)) {
             return .CHARACTER_DEVICE;
-        } else if (std.os.S.ISBLK(mode)) {
+        } else if (std.posix.S.ISBLK(mode)) {
             return .BLOCK_DEVICE;
-        } else if (std.os.S.ISLNK(mode)) {
+        } else if (std.posix.S.ISLNK(mode)) {
             return .SYMBOLIC_LINK;
             // } else if (std.os.S.ISSOCK(mode)) {
             //     stat_wasi.fs_filetype = std.os.wasi.filetype_t.SOCKET_STREAM; // not sure if this is SOCKET_STREAM or SOCKET_DGRAM
@@ -885,7 +882,40 @@ const Helpers = struct {
         }
     }
 
-    fn fdstatGetWindows(fd: std.os.fd_t, errno: *Errno) std.os.wasi.fdstat_t {
+    const WASI_RIGHTS_ALL: std.os.wasi.rights_t = .{
+        .FD_DATASYNC = true,
+        .FD_READ = true,
+        .FD_SEEK = true,
+        .FD_FDSTAT_SET_FLAGS = true,
+        .FD_SYNC = true,
+        .FD_TELL = true,
+        .FD_WRITE = true,
+        .FD_ADVISE = true,
+        .FD_ALLOCATE = true,
+        .PATH_CREATE_DIRECTORY = true,
+        .PATH_CREATE_FILE = true,
+        .PATH_LINK_SOURCE = true,
+        .PATH_LINK_TARGET = true,
+        .PATH_OPEN = true,
+        .FD_READDIR = true,
+        .PATH_READLINK = true,
+        .PATH_RENAME_SOURCE = true,
+        .PATH_RENAME_TARGET = true,
+        .PATH_FILESTAT_GET = true,
+        .PATH_FILESTAT_SET_SIZE = true,
+        .PATH_FILESTAT_SET_TIMES = true,
+        .FD_FILESTAT_GET = true,
+        .FD_FILESTAT_SET_SIZE = true,
+        .FD_FILESTAT_SET_TIMES = true,
+        .PATH_SYMLINK = true,
+        .PATH_REMOVE_DIRECTORY = true,
+        .PATH_UNLINK_FILE = true,
+        .POLL_FD_READWRITE = true,
+        .SOCK_SHUTDOWN = true,
+        .SOCK_ACCEPT = true,
+    };
+
+    fn fdstatGetWindows(fd: std.posix.fd_t, errno: *Errno) std.os.wasi.fdstat_t {
         if (builtin.os.tag != .windows) {
             @compileError("This function should only be called on the Windows OS.");
         }
@@ -893,8 +923,8 @@ const Helpers = struct {
         var stat_wasi = std.os.wasi.fdstat_t{
             .fs_filetype = std.os.wasi.filetype_t.REGULAR_FILE,
             .fs_flags = 0,
-            .fs_rights_base = std.os.wasi.RIGHT.ALL,
-            .fs_rights_inheriting = std.os.wasi.RIGHT.ALL,
+            .fs_rights_base = WASI_RIGHTS_ALL,
+            .fs_rights_inheriting = WASI_RIGHTS_ALL,
         };
 
         var info: WindowsApi.BY_HANDLE_FILE_INFORMATION = undefined;
@@ -902,11 +932,11 @@ const Helpers = struct {
             stat_wasi.fs_filetype = windowsFileAttributeToWasiFiletype(info.dwFileAttributes);
 
             if (stat_wasi.fs_filetype == .DIRECTORY) {
-                stat_wasi.fs_rights_base &= ~std.os.wasi.RIGHT.FD_SEEK;
+                stat_wasi.fs_rights_base.FD_SEEK = false;
             }
 
             if (info.dwFileAttributes & std.os.windows.FILE_ATTRIBUTE_READONLY != 0) {
-                stat_wasi.fs_rights_base &= ~std.os.wasi.RIGHT.FD_WRITE;
+                stat_wasi.fs_rights_base.FD_WRITE = false;
             }
         } else {
             errno.* = Errno.getLastWin32Error();
@@ -917,52 +947,53 @@ const Helpers = struct {
         return stat_wasi;
     }
 
-    fn fdstatGetPosix(fd: std.os.fd_t, errno: *Errno) std.os.wasi.fdstat_t {
+    fn fdstatGetPosix(fd: std.posix.fd_t, errno: *Errno) std.os.wasi.fdstat_t {
         if (builtin.os.tag == .windows) {
             @compileError("This function should only be called on an OS that supports posix APIs.");
         }
 
         var stat_wasi = std.os.wasi.fdstat_t{
             .fs_filetype = std.os.wasi.filetype_t.UNKNOWN,
-            .fs_flags = 0,
-            .fs_rights_base = std.os.wasi.RIGHT.ALL,
-            .fs_rights_inheriting = std.os.wasi.RIGHT.ALL,
+            .fs_flags = .{},
+            .fs_rights_base = WASI_RIGHTS_ALL,
+            .fs_rights_inheriting = WASI_RIGHTS_ALL,
         };
 
-        if (std.os.fcntl(fd, std.os.F.GETFL, 0)) |fd_flags| {
-            if (std.os.fstat(fd)) |fd_stat| {
+        if (std.posix.fcntl(fd, std.posix.F.GETFL, 0)) |fd_flags| {
+            if (std.posix.fstat(fd)) |fd_stat| {
+                const flags: std.posix.O = @bitCast(@as(u32, @intCast(fd_flags)));
 
                 // filetype
                 stat_wasi.fs_filetype = posixModeToWasiFiletype(fd_stat.mode);
 
                 // flags
-                if (fd_flags & std.os.O.APPEND != 0) {
-                    stat_wasi.fs_flags |= std.os.wasi.FDFLAG.APPEND;
+                if (flags.APPEND) {
+                    stat_wasi.fs_flags.APPEND = true;
                 }
-                if (fd_flags & std.os.O.DSYNC != 0) {
-                    stat_wasi.fs_flags |= std.os.wasi.FDFLAG.DSYNC;
+                if (flags.DSYNC) {
+                    stat_wasi.fs_flags.DSYNC = true;
                 }
-                if (fd_flags & std.os.O.NONBLOCK != 0) {
-                    stat_wasi.fs_flags |= std.os.wasi.FDFLAG.NONBLOCK;
+                if (flags.NONBLOCK) {
+                    stat_wasi.fs_flags.NONBLOCK = true;
                 }
-                if (builtin.os.tag != .macos and fd_flags & std.os.O.RSYNC != 0) {
-                    stat_wasi.fs_flags |= std.os.wasi.FDFLAG.RSYNC;
+                if (builtin.os.tag != .macos and builtin.os.tag != .linux and flags.RSYNC) {
+                    stat_wasi.fs_flags.RSYNC = true;
                 }
-                if (fd_flags & std.os.O.SYNC != 0) {
-                    stat_wasi.fs_flags |= std.os.wasi.FDFLAG.SYNC;
+                if (flags.SYNC) {
+                    stat_wasi.fs_flags.SYNC = true;
                 }
 
                 // rights
-                if (fd_flags & std.os.O.RDWR != 0) {
+                if (flags.ACCMODE == .RDWR) {
                     // noop since all rights includes this by default
-                } else if (fd_flags & std.os.O.RDONLY != 0) {
-                    stat_wasi.fs_rights_base &= ~std.os.wasi.RIGHT.FD_WRITE;
-                } else if (fd_flags & std.os.O.WRONLY != 0) {
-                    stat_wasi.fs_rights_base &= ~std.os.wasi.RIGHT.FD_READ;
+                } else if (flags.ACCMODE == .RDONLY) {
+                    stat_wasi.fs_rights_base.FD_WRITE = false;
+                } else if (flags.ACCMODE == .WRONLY) {
+                    stat_wasi.fs_rights_base.FD_READ = false;
                 }
 
                 if (stat_wasi.fs_filetype == .DIRECTORY) {
-                    stat_wasi.fs_rights_base &= ~std.os.wasi.RIGHT.FD_SEEK;
+                    stat_wasi.fs_rights_base.FD_SEEK = false;
                 }
             } else |err| {
                 errno.* = Errno.translateError(err);
@@ -974,7 +1005,7 @@ const Helpers = struct {
         return stat_wasi;
     }
 
-    fn fdstatSetFlagsWindows(fd_info: *const WasiContext.FdInfo, fdflags: WasiFdFlags, errno: *Errno) ?std.os.fd_t {
+    fn fdstatSetFlagsWindows(fd_info: *const WasiContext.FdInfo, fdflags: WasiFdFlags, errno: *Errno) ?std.posix.fd_t {
         const w = std.os.windows;
 
         const file_pos = w.SetFilePointerEx_CURRENT_get(fd_info.fd) catch |err| {
@@ -1062,10 +1093,11 @@ const Helpers = struct {
         return fd_new;
     }
 
-    fn fdstatSetFlagsPosix(fd_info: *const WasiContext.FdInfo, fdflags: WasiFdFlags, errno: *Errno) ?std.os.fd_t {
-        const flags: u32 = fdflagsToFlagsPosix(fdflags);
+    fn fdstatSetFlagsPosix(fd_info: *const WasiContext.FdInfo, fdflags: WasiFdFlags, errno: *Errno) ?std.posix.fd_t {
+        const flags = fdflagsToFlagsPosix(fdflags);
+        const flags_int = @as(u32, @bitCast(flags));
 
-        if (std.os.fcntl(fd_info.fd, std.os.F.SETFL, flags)) |_| {} else |err| {
+        if (std.posix.fcntl(fd_info.fd, std.posix.F.SETFL, flags_int)) |_| {} else |err| {
             errno.* = Errno.translateError(err);
         }
 
@@ -1073,17 +1105,18 @@ const Helpers = struct {
         return null;
     }
 
-    fn fdFilestatSetTimesWindows(fd: std.os.fd_t, timestamp_wasi_access: u64, timestamp_wasi_modified: u64, fstflags: u32, errno: *Errno) void {
+    fn fdFilestatSetTimesWindows(fd: std.posix.fd_t, timestamp_wasi_access: u64, timestamp_wasi_modified: u64, fstflags: u32, errno: *Errno) void {
         var filetime_now: WindowsApi.FILETIME = undefined; // helps avoid 2 calls to GetSystemTimeAsFiletime
         var filetime_now_needs_set: bool = true;
 
         var access_time: std.os.windows.FILETIME = undefined;
         var access_time_was_set: bool = false;
-        if (fstflags & std.os.wasi.FILESTAT_SET_ATIM != 0) {
+        const flags: std.os.wasi.fstflags_t = @bitCast(fstflags);
+        if (flags.ATIM) {
             access_time = std.os.windows.nanoSecondsToFileTime(timestamp_wasi_access);
             access_time_was_set = true;
         }
-        if (fstflags & std.os.wasi.FILESTAT_SET_ATIM_NOW != 0) {
+        if (flags.ATIM_NOW) {
             std.os.windows.kernel32.GetSystemTimeAsFileTime(&filetime_now);
             filetime_now_needs_set = false;
             access_time = filetime_now;
@@ -1112,12 +1145,21 @@ const Helpers = struct {
         };
     }
 
-    fn fdFilestatSetTimesPosix(fd: std.os.fd_t, timestamp_wasi_access: u64, timestamp_wasi_modified: u64, fstflags: u32, errno: *Errno) void {
+    fn timespecFromTimestamp(timestamp: u64) std.posix.timespec {
+        const tv_sec = timestamp / 1_000_000_000;
+        const tv_nsec = timestamp - tv_sec * 1_000_000_000;
+        return .{
+            .tv_sec = @as(isize, @intCast(tv_sec)),
+            .tv_nsec = @as(isize, @intCast(tv_nsec)),
+        };
+    }
+
+    fn fdFilestatSetTimesPosix(fd: std.posix.fd_t, timestamp_wasi_access: u64, timestamp_wasi_modified: u64, fstflags: u32, errno: *Errno) void {
         const is_darwin = builtin.os.tag.isDarwin();
         const UTIME_NOW: i64 = if (is_darwin) @as(i32, -1) else (1 << 30) - 1;
         const UTIME_OMIT: i64 = if (is_darwin) @as(i32, -2) else (1 << 30) - 2;
 
-        var times = [2]std.os.timespec{
+        var times = [2]std.posix.timespec{
             .{ // access time
                 .tv_sec = 0,
                 .tv_nsec = UTIME_OMIT,
@@ -1128,24 +1170,25 @@ const Helpers = struct {
             },
         };
 
-        if (fstflags & std.os.wasi.FILESTAT_SET_ATIM != 0) {
-            const ts: std.os.wasi.timespec = std.os.wasi.timespec.fromTimestamp(timestamp_wasi_access);
+        const flags: std.os.wasi.fstflags_t = @bitCast(@as(u16, @intCast(fstflags)));
+        if (flags.ATIM) {
+            const ts: std.posix.timespec = timespecFromTimestamp(timestamp_wasi_access);
             times[0].tv_sec = ts.tv_sec;
             times[0].tv_nsec = ts.tv_nsec;
         }
-        if (fstflags & std.os.wasi.FILESTAT_SET_ATIM_NOW != 0) {
+        if (flags.ATIM_NOW) {
             times[0].tv_nsec = UTIME_NOW;
         }
-        if (fstflags & std.os.wasi.FILESTAT_SET_MTIM != 0) {
-            const ts: std.os.wasi.timespec = std.os.wasi.timespec.fromTimestamp(timestamp_wasi_modified);
+        if (flags.MTIM) {
+            const ts: std.posix.timespec = timespecFromTimestamp(timestamp_wasi_modified);
             times[1].tv_sec = ts.tv_sec;
             times[1].tv_nsec = ts.tv_nsec;
         }
-        if (fstflags & std.os.wasi.FILESTAT_SET_MTIM_NOW != 0) {
+        if (flags.MTIM_NOW) {
             times[1].tv_nsec = UTIME_NOW;
         }
 
-        std.os.futimens(fd, &times) catch |err| {
+        std.posix.futimens(fd, &times) catch |err| {
             errno.* = Errno.translateError(err);
         };
     }
@@ -1154,7 +1197,7 @@ const Helpers = struct {
         return (high << 32) | low;
     }
 
-    fn filestatGetWindows(fd: std.os.fd_t, errno: *Errno) std.os.wasi.filestat_t {
+    fn filestatGetWindows(fd: std.posix.fd_t, errno: *Errno) std.os.wasi.filestat_t {
         if (builtin.os.tag != .windows) {
             @compileError("This function should only be called on an OS that supports posix APIs.");
         }
@@ -1178,14 +1221,14 @@ const Helpers = struct {
         return stat_wasi;
     }
 
-    fn filestatGetPosix(fd: std.os.fd_t, errno: *Errno) std.os.wasi.filestat_t {
+    fn filestatGetPosix(fd: std.posix.fd_t, errno: *Errno) std.os.wasi.filestat_t {
         if (builtin.os.tag == .windows) {
             @compileError("This function should only be called on an OS that supports posix APIs.");
         }
 
         var stat_wasi: std.os.wasi.filestat_t = undefined;
 
-        if (std.os.fstat(fd)) |stat| {
+        if (std.posix.fstat(fd)) |stat| {
             stat_wasi.dev = if (builtin.os.tag == .macos) @as(u32, @bitCast(stat.dev)) else stat.dev;
             stat_wasi.ino = stat.ino;
             stat_wasi.filetype = posixModeToWasiFiletype(stat.mode);
@@ -1209,7 +1252,7 @@ const Helpers = struct {
 
     // As of this 0.10.1, the zig stdlib has a bug in std.os.open() that doesn't respect the append flag properly.
     // To get this working, we'll just use NtCreateFile directly.
-    fn openPathWindows(path: []const u8, lookupflags: WasiLookupFlags, openflags: WasiOpenFlags, fdflags: WasiFdFlags, rights: WasiRights, errno: *Errno) ?std.os.fd_t {
+    fn openPathWindows(path: []const u8, lookupflags: WasiLookupFlags, openflags: WasiOpenFlags, fdflags: WasiFdFlags, rights: WasiRights, errno: *Errno) ?std.posix.fd_t {
         if (builtin.os.tag != .windows) {
             @compileError("This function should only be called on an OS that supports windows APIs.");
         }
@@ -1286,7 +1329,7 @@ const Helpers = struct {
                         errno.* = Errno.LOOP;
                     }
                     if (rc == .SUCCESS) {
-                        std.os.close(fd);
+                        std.posix.close(fd);
                     }
                     return null;
                 }
@@ -1317,47 +1360,48 @@ const Helpers = struct {
         return null;
     }
 
-    fn openPathPosix(path: []const u8, lookupflags: WasiLookupFlags, openflags: WasiOpenFlags, fdflags: WasiFdFlags, rights: WasiRights, errno: *Errno) ?std.os.fd_t {
+    fn openPathPosix(path: []const u8, lookupflags: WasiLookupFlags, openflags: WasiOpenFlags, fdflags: WasiFdFlags, rights: WasiRights, errno: *Errno) ?std.posix.fd_t {
         if (builtin.os.tag == .windows) {
             @compileError("This function should only be called on an OS that supports posix APIs.");
         }
 
-        var flags: u32 = 0;
+        var flags: std.posix.O = .{};
         if (openflags.creat) {
-            flags |= std.os.O.CREAT;
+            flags.CREAT = true;
         }
         if (openflags.directory) {
-            flags |= std.os.O.DIRECTORY;
+            flags.DIRECTORY = true;
         }
         if (openflags.excl) {
-            flags |= std.os.O.EXCL;
+            flags.EXCL = true;
         }
         if (openflags.trunc) {
-            flags |= std.os.O.TRUNC;
+            flags.TRUNC = true;
         }
 
         if (lookupflags.symlink_follow == false) {
-            flags |= std.os.O.NOFOLLOW;
+            flags.NOFOLLOW = true;
         }
 
         const fdflags_os = fdflagsToFlagsPosix(fdflags);
-        flags |= fdflags_os;
+        const combined = @as(u32, @bitCast(flags)) | @as(u32, @bitCast(fdflags_os));
+        flags = @bitCast(combined);
 
         if (rights.fd_read and rights.fd_write) {
             if (openflags.directory) {
-                flags |= std.os.O.RDONLY;
+                flags.ACCMODE = .RDONLY;
             } else {
-                flags |= std.os.O.RDWR;
+                flags.ACCMODE = .RDWR;
             }
         } else if (rights.fd_read) {
-            flags |= std.os.O.RDONLY;
+            flags.ACCMODE = .RDONLY;
         } else if (rights.fd_write) {
-            flags |= std.os.O.WRONLY;
+            flags.ACCMODE = .WRONLY;
         }
 
-        const S = std.os.linux.S;
-        const mode: std.os.mode_t = S.IRUSR | S.IWUSR | S.IRGRP | S.IWGRP | S.IROTH;
-        if (std.os.open(path, flags, mode)) |fd| {
+        const S = std.posix.S;
+        const mode: std.posix.mode_t = S.IRUSR | S.IWUSR | S.IRGRP | S.IWGRP | S.IROTH;
+        if (std.posix.open(path, flags, mode)) |fd| {
             return fd;
         } else |err| {
             errno.* = Errno.translateError(err);
@@ -1393,10 +1437,10 @@ const Helpers = struct {
             if (file_index < fd_info.dir_entries.items.len) {
                 for (fd_info.dir_entries.items[file_index..]) |entry| {
                     const cookie = file_index + 1;
-                    writer.writeIntLittle(u64, cookie) catch break;
-                    writer.writeIntLittle(u64, entry.inode) catch break;
-                    writer.writeIntLittle(u32, signedCast(u32, entry.filename.len, errno)) catch break;
-                    writer.writeIntLittle(u32, @intFromEnum(entry.filetype)) catch break;
+                    writer.writeInt(u64, cookie, .little) catch break;
+                    writer.writeInt(u64, entry.inode, .little) catch break;
+                    writer.writeInt(u32, signedCast(u32, entry.filename.len, errno), .little) catch break;
+                    writer.writeInt(u32, @intFromEnum(entry.filetype), .little) catch break;
                     _ = writer.write(entry.filename) catch break;
 
                     file_index += 1;
@@ -1424,7 +1468,7 @@ const Helpers = struct {
 
         var file_info_buffer: [1024]u8 align(@alignOf(WindowsApi.FILE_ID_FULL_DIR_INFORMATION)) = undefined;
         var io: std.os.windows.IO_STATUS_BLOCK = undefined;
-        var rc: std.os.windows.NTSTATUS = std.os.windows.ntdll.NtQueryDirectoryFile(
+        const rc: std.os.windows.NTSTATUS = std.os.windows.ntdll.NtQueryDirectoryFile(
             fd_info.fd,
             null,
             null,
@@ -1489,7 +1533,7 @@ const Helpers = struct {
 
     fn enumerateDirEntriesDarwin(fd_info: *WasiContext.FdInfo, restart_scan: bool, errno: *Errno) bool {
         if (restart_scan) {
-            std.os.lseek_SET(fd_info.fd, 0) catch |err| {
+            std.posix.lseek_SET(fd_info.fd, 0) catch |err| {
                 errno.* = Errno.translateError(err);
                 return false;
             };
@@ -1499,8 +1543,8 @@ const Helpers = struct {
 
         var dirent_buffer: [1024]u8 align(@alignOf(dirent_t)) = undefined;
         var unused_seek: i64 = 0;
-        const rc = std.os.system.__getdirentries64(fd_info.fd, &dirent_buffer, dirent_buffer.len, &unused_seek);
-        errno.* = switch (std.c.getErrno(rc)) {
+        const rc = std.c.darwin.__getdirentries64(fd_info.fd, &dirent_buffer, dirent_buffer.len, &unused_seek);
+        errno.* = switch (std.posix.errno(rc)) {
             .SUCCESS => .SUCCESS,
             .BADF => .BADF,
             .FAULT => .FAULT,
@@ -1520,13 +1564,13 @@ const Helpers = struct {
         var buffer_offset: usize = 0;
         while (buffer_offset < rc) {
             const dirent_entry = @as(*align(1) dirent_t, @ptrCast(dirent_buffer[buffer_offset..]));
-            buffer_offset += dirent_entry.d_reclen;
+            buffer_offset += dirent_entry.reclen;
 
             // TODO length should be (d_reclen - 2 - offsetof(dirent64, d_name))
             // const filename: []u8 = std.mem.sliceTo(@ptrCast([*:0]u8, &dirent_entry.d_name), 0);
-            const filename: []u8 = @as([*]u8, @ptrCast(&dirent_entry.d_name))[0..dirent_entry.d_namlen];
+            const filename: []u8 = @as([*]u8, @ptrCast(&dirent_entry.name))[0..dirent_entry.d_namlen];
 
-            const filetype: std.os.wasi.filetype_t = switch (dirent_entry.d_type) {
+            const filetype: std.os.wasi.filetype_t = switch (dirent_entry.type) {
                 std.c.DT.UNKNOWN => .UNKNOWN,
                 std.c.DT.FIFO => .UNKNOWN,
                 std.c.DT.CHR => .CHARACTER_DEVICE,
@@ -1559,7 +1603,7 @@ const Helpers = struct {
 
     fn enumerateDirEntriesLinux(fd_info: *WasiContext.FdInfo, restart_scan: bool, errno: *Errno) bool {
         if (restart_scan) {
-            std.os.lseek_SET(fd_info.fd, 0) catch |err| {
+            std.posix.lseek_SET(fd_info.fd, 0) catch |err| {
                 errno.* = Errno.translateError(err);
                 return false;
             };
@@ -1567,7 +1611,7 @@ const Helpers = struct {
 
         var dirent_buffer: [1024]u8 align(@alignOf(std.os.linux.dirent64)) = undefined;
         const rc = std.os.linux.getdents64(fd_info.fd, &dirent_buffer, dirent_buffer.len);
-        errno.* = switch (std.os.linux.getErrno(rc)) {
+        errno.* = switch (std.posix.errno(rc)) {
             .SUCCESS => Errno.SUCCESS,
             .BADF => unreachable, // should never happen since this call is wrapped by fdLookup
             .FAULT => Errno.FAULT,
@@ -1587,12 +1631,12 @@ const Helpers = struct {
         var buffer_offset: usize = 0;
         while (buffer_offset < rc) {
             const dirent_entry = @as(*align(1) std.os.linux.dirent64, @ptrCast(dirent_buffer[buffer_offset..]));
-            buffer_offset += dirent_entry.d_reclen;
+            buffer_offset += dirent_entry.reclen;
 
             // TODO length should be (d_reclen - 2 - offsetof(dirent64, d_name))
-            const filename: []u8 = std.mem.sliceTo(@as([*:0]u8, @ptrCast(&dirent_entry.d_name)), 0);
+            const filename: []u8 = std.mem.sliceTo(@as([*:0]u8, @ptrCast(&dirent_entry.name)), 0);
 
-            const filetype: std.os.wasi.filetype_t = switch (dirent_entry.d_type) {
+            const filetype: std.os.wasi.filetype_t = switch (dirent_entry.type) {
                 std.os.linux.DT.BLK => .BLOCK_DEVICE,
                 std.os.linux.DT.CHR => .CHARACTER_DEVICE,
                 std.os.linux.DT.DIR => .DIRECTORY,
@@ -1609,7 +1653,7 @@ const Helpers = struct {
             };
 
             fd_info.dir_entries.append(WasiDirEntry{
-                .inode = @as(u64, @bitCast(dirent_entry.d_ino)),
+                .inode = @as(u64, @bitCast(dirent_entry.ino)),
                 .filetype = filetype,
                 .filename = filename_duped,
             }) catch |err| {
@@ -1690,7 +1734,7 @@ fn wasi_environ_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]c
 fn wasi_clock_res_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
     var errno = Errno.SUCCESS;
 
-    const system_clockid: i32 = Helpers.convertClockId(params[0].I32, &errno);
+    const system_clockid: i32 = Helpers.convertClockId(params[0].I32);
     const timestamp_mem_begin = Helpers.signedCast(u32, params[1].I32, &errno);
 
     if (errno == .SUCCESS) {
@@ -1715,8 +1759,8 @@ fn wasi_clock_res_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const 
                 }
             }
         } else {
-            var ts: std.os.system.timespec = undefined;
-            if (std.os.clock_getres(system_clockid, &ts)) {
+            var ts: std.posix.timespec = undefined;
+            if (std.posix.clock_getres(system_clockid, &ts)) {
                 freqency_ns = @as(u64, @intCast(ts.tv_nsec));
             } else |_| {
                 errno = Errno.INVAL;
@@ -1732,7 +1776,7 @@ fn wasi_clock_res_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const 
 fn wasi_clock_time_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
     var errno = Errno.SUCCESS;
 
-    const system_clockid: i32 = Helpers.convertClockId(params[0].I32, &errno);
+    const system_clockid: i32 = Helpers.convertClockId(params[0].I32);
     //const precision = params[1].I64; // unused
     const timestamp_mem_begin = Helpers.signedCast(u32, params[2].I32, &errno);
 
@@ -1785,8 +1829,8 @@ fn wasi_clock_time_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const
                 else => unreachable,
             }
         } else {
-            var ts: std.os.system.timespec = undefined;
-            if (std.os.clock_gettime(system_clockid, &ts)) {
+            var ts: std.posix.timespec = undefined;
+            if (std.posix.clock_gettime(system_clockid, &ts)) {
                 timestamp_ns = Helpers.posixTimespecToWasi(ts);
             } else |_| {
                 errno = Errno.INVAL;
@@ -1806,7 +1850,7 @@ fn fd_wasi_datasync(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const 
     var errno = Errno.SUCCESS;
 
     if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-        std.os.fdatasync(fd_info.fd) catch |err| {
+        std.posix.fdatasync(fd_info.fd) catch |err| {
             errno = Errno.translateError(err);
         };
     }
@@ -1823,14 +1867,14 @@ fn fd_wasi_fdstat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*
 
     if (errno == .SUCCESS) {
         if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-            const fd_os: std.os.fd_t = fd_info.fd;
+            const fd_os = fd_info.fd;
             const stat: std.os.wasi.fdstat_t = if (builtin.os.tag == .windows) Helpers.fdstatGetWindows(fd_os, &errno) else Helpers.fdstatGetPosix(fd_os, &errno);
 
             if (errno == .SUCCESS) {
                 Helpers.writeIntToMemory(u8, @intFromEnum(stat.fs_filetype), fdstat_mem_offset + 0, module, &errno);
-                Helpers.writeIntToMemory(u16, stat.fs_flags, fdstat_mem_offset + 2, module, &errno);
-                Helpers.writeIntToMemory(u64, stat.fs_rights_base, fdstat_mem_offset + 8, module, &errno);
-                Helpers.writeIntToMemory(u64, stat.fs_rights_inheriting, fdstat_mem_offset + 16, module, &errno);
+                Helpers.writeIntToMemory(u16, @bitCast(stat.fs_flags), fdstat_mem_offset + 2, module, &errno);
+                Helpers.writeIntToMemory(u64, @bitCast(stat.fs_rights_base), fdstat_mem_offset + 8, module, &errno);
+                Helpers.writeIntToMemory(u64, @bitCast(stat.fs_rights_inheriting), fdstat_mem_offset + 16, module, &errno);
             }
         }
     }
@@ -1913,9 +1957,9 @@ fn fd_wasi_read(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const
 
     if (errno == .SUCCESS) {
         if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-            var stack_iov = [_]std.os.iovec{undefined} ** 1024;
-            if (Helpers.initIovecs(std.os.iovec, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
-                if (std.os.readv(fd_info.fd, iov)) |read_bytes| {
+            var stack_iov = [_]std.posix.iovec{undefined} ** 1024;
+            if (Helpers.initIovecs(std.posix.iovec, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
+                if (std.posix.readv(fd_info.fd, iov)) |read_bytes| {
                     if (read_bytes <= std.math.maxInt(u32)) {
                         Helpers.writeIntToMemory(u32, @as(u32, @intCast(read_bytes)), bytes_read_out_offset, module, &errno);
                     } else {
@@ -1977,9 +2021,9 @@ fn fd_wasi_pread(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]cons
 
     if (errno == .SUCCESS) {
         if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-            var stack_iov = [_]std.os.iovec{undefined} ** 1024;
-            if (Helpers.initIovecs(std.os.iovec, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
-                if (std.os.preadv(fd_info.fd, iov, read_offset)) |read_bytes| {
+            var stack_iov = [_]std.posix.iovec{undefined} ** 1024;
+            if (Helpers.initIovecs(std.posix.iovec, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
+                if (std.posix.preadv(fd_info.fd, iov, read_offset)) |read_bytes| {
                     if (read_bytes <= std.math.maxInt(u32)) {
                         Helpers.writeIntToMemory(u32, @as(u32, @intCast(read_bytes)), bytes_read_out_offset, module, &errno);
                     } else {
@@ -2010,21 +2054,18 @@ fn fd_wasi_advise(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Va
             // fadvise isn't available on windows or macos, but fadvise is just an optimization hint, so don't
             // return a bad error code
             if (builtin.os.tag == .linux) {
-                const advice: usize = switch (advice_wasi) {
-                    std.os.wasi.ADVICE_NORMAL => std.os.POSIX_FADV.NORMAL,
-                    std.os.wasi.ADVICE_SEQUENTIAL => std.os.POSIX_FADV.SEQUENTIAL,
-                    std.os.wasi.ADVICE_RANDOM => std.os.POSIX_FADV.RANDOM,
-                    std.os.wasi.ADVICE_WILLNEED => std.os.POSIX_FADV.WILLNEED,
-                    std.os.wasi.ADVICE_DONTNEED => std.os.POSIX_FADV.DONTNEED,
-                    std.os.wasi.ADVICE_NOREUSE => std.os.POSIX_FADV.NOREUSE,
-                    else => blk: {
-                        errno = Errno.INVAL;
-                        break :blk 0;
-                    },
+                const wasi_advice: std.os.wasi.advice_t = @enumFromInt(advice_wasi);
+                const advice: usize = switch (wasi_advice) {
+                    std.os.wasi.advice_t.NORMAL => std.os.linux.POSIX_FADV.NORMAL,
+                    std.os.wasi.advice_t.SEQUENTIAL => std.os.linux.POSIX_FADV.SEQUENTIAL,
+                    std.os.wasi.advice_t.RANDOM => std.os.linux.POSIX_FADV.RANDOM,
+                    std.os.wasi.advice_t.WILLNEED => std.os.linux.POSIX_FADV.WILLNEED,
+                    std.os.wasi.advice_t.DONTNEED => std.os.linux.POSIX_FADV.DONTNEED,
+                    std.os.wasi.advice_t.NOREUSE => std.os.linux.POSIX_FADV.NOREUSE,
                 };
 
                 if (errno == .SUCCESS) {
-                    const ret = @as(std.os.linux.E, @enumFromInt(std.os.system.fadvise(fd_info.fd, offset, length, advice)));
+                    const ret = @as(std.os.linux.E, @enumFromInt(std.os.linux.fadvise(fd_info.fd, offset, length, advice)));
                     errno = switch (ret) {
                         .SUCCESS => Errno.SUCCESS,
                         .SPIPE => Errno.SPIPE,
@@ -2071,7 +2112,7 @@ fn fd_wasi_allocate(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const 
         } else if (builtin.os.tag == .linux) {
             const mode = 0;
             const rc = std.os.linux.fallocate(fd_info.fd, mode, offset, length_relative);
-            errno = switch (std.os.linux.getErrno(rc)) {
+            errno = switch (std.posix.errno(rc)) {
                 .SUCCESS => Errno.SUCCESS,
                 .BADF => unreachable, // should never happen since this call is wrapped by fdLookup
                 .FBIG => Errno.FBIG,
@@ -2093,7 +2134,7 @@ fn fd_wasi_allocate(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const 
                 // so we need to emulate that behavior here
                 const length_total = @as(u64, @intCast(@as(i128, offset) + length_relative));
                 if (stat.size < length_total) {
-                    std.os.ftruncate(fd_info.fd, length_total) catch |err| {
+                    std.posix.ftruncate(fd_info.fd, length_total) catch |err| {
                         errno = Errno.translateError(err);
                     };
                 }
@@ -2155,7 +2196,7 @@ fn fd_wasi_filestat_set_size(userdata: ?*anyopaque, _: *ModuleInstance, params: 
         if (Helpers.isStdioHandle(fd_wasi)) {
             errno = Errno.BADF;
         } else if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-            std.os.ftruncate(fd_info.fd, size) catch |err| {
+            std.posix.ftruncate(fd_info.fd, size) catch |err| {
                 errno = Errno.translateError(err);
             };
         }
@@ -2171,14 +2212,14 @@ fn fd_wasi_filestat_set_times(userdata: ?*anyopaque, _: *ModuleInstance, params:
     const fd_wasi = @as(u32, @bitCast(params[0].I32));
     const timestamp_wasi_access = Helpers.signedCast(u64, params[1].I64, &errno);
     const timestamp_wasi_modified = Helpers.signedCast(u64, params[2].I64, &errno);
-    const fstflags = @as(u32, @bitCast(params[3].I32));
+    const fstflags: std.os.wasi.fstflags_t = @bitCast(@as(u16, @intCast(params[3].I32)));
 
     if (errno == .SUCCESS) {
-        if (fstflags & std.os.wasi.FILESTAT_SET_ATIM != 0 and fstflags & std.os.wasi.FILESTAT_SET_ATIM_NOW != 0) {
+        if (fstflags.ATIM and fstflags.ATIM_NOW) {
             errno = Errno.INVAL;
         }
 
-        if (fstflags & std.os.wasi.FILESTAT_SET_MTIM != 0 and fstflags & std.os.wasi.FILESTAT_SET_MTIM_NOW != 0) {
+        if (fstflags.MTIM and fstflags.MTIM_NOW) {
             errno = Errno.INVAL;
         }
     }
@@ -2188,7 +2229,8 @@ fn fd_wasi_filestat_set_times(userdata: ?*anyopaque, _: *ModuleInstance, params:
             errno = Errno.BADF;
         } else if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
             const fd_filestat_set_times_func = if (builtin.os.tag == .windows) Helpers.fdFilestatSetTimesWindows else Helpers.fdFilestatSetTimesPosix;
-            fd_filestat_set_times_func(fd_info.fd, timestamp_wasi_access, timestamp_wasi_modified, fstflags, &errno);
+            const flags_int: u32 = @as(u16, @bitCast(fstflags));
+            fd_filestat_set_times_func(fd_info.fd, timestamp_wasi_access, timestamp_wasi_modified, flags_int, &errno);
         }
     }
 
@@ -2213,24 +2255,24 @@ fn fd_wasi_seek(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const
                         .Set => {
                             if (offset >= 0) {
                                 const offset_unsigned = @as(u64, @intCast(offset));
-                                std.os.lseek_SET(fd_os, offset_unsigned) catch |err| {
+                                std.posix.lseek_SET(fd_os, offset_unsigned) catch |err| {
                                     errno = Errno.translateError(err);
                                 };
                             }
                         },
                         .Cur => {
-                            std.os.lseek_CUR(fd_os, offset) catch |err| {
+                            std.posix.lseek_CUR(fd_os, offset) catch |err| {
                                 errno = Errno.translateError(err);
                             };
                         },
                         .End => {
-                            std.os.lseek_END(fd_os, offset) catch |err| {
+                            std.posix.lseek_END(fd_os, offset) catch |err| {
                                 errno = Errno.translateError(err);
                             };
                         },
                     }
 
-                    if (std.os.lseek_CUR_get(fd_os)) |filepos| {
+                    if (std.posix.lseek_CUR_get(fd_os)) |filepos| {
                         Helpers.writeIntToMemory(u64, filepos, filepos_out_offset, module, &errno);
                     } else |err| {
                         errno = Errno.translateError(err);
@@ -2257,7 +2299,7 @@ fn fd_wasi_tell(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const
 
     if (errno == .SUCCESS) {
         if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-            if (std.os.lseek_CUR_get(fd_info.fd)) |filepos| {
+            if (std.posix.lseek_CUR_get(fd_info.fd)) |filepos| {
                 Helpers.writeIntToMemory(u64, filepos, filepos_out_offset, module, &errno);
             } else |err| {
                 errno = Errno.translateError(err);
@@ -2279,9 +2321,9 @@ fn fd_wasi_write(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]cons
 
     if (errno == .SUCCESS) {
         if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-            var stack_iov = [_]std.os.iovec_const{undefined} ** 1024;
-            if (Helpers.initIovecs(std.os.iovec_const, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
-                if (std.os.writev(fd_info.fd, iov)) |written_bytes| {
+            var stack_iov = [_]std.posix.iovec_const{undefined} ** 1024;
+            if (Helpers.initIovecs(std.posix.iovec_const, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
+                if (std.posix.writev(fd_info.fd, iov)) |written_bytes| {
                     Helpers.writeIntToMemory(u32, @as(u32, @intCast(written_bytes)), bytes_written_out_offset, module, &errno);
                 } else |err| {
                     errno = Errno.translateError(err);
@@ -2305,9 +2347,9 @@ fn fd_wasi_pwrite(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]con
 
     if (errno == .SUCCESS) {
         if (context.fdLookup(fd_wasi, &errno)) |fd_info| {
-            var stack_iov = [_]std.os.iovec_const{undefined} ** 1024;
-            if (Helpers.initIovecs(std.os.iovec_const, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
-                if (std.os.pwritev(fd_info.fd, iov, write_offset)) |written_bytes| {
+            var stack_iov = [_]std.posix.iovec_const{undefined} ** 1024;
+            if (Helpers.initIovecs(std.posix.iovec_const, &stack_iov, &errno, module, iovec_array_begin, iovec_array_count)) |iov| {
+                if (std.posix.pwritev(fd_info.fd, iov, write_offset)) |written_bytes| {
                     Helpers.writeIntToMemory(u32, @as(u32, @intCast(written_bytes)), bytes_written_out_offset, module, &errno);
                 } else |err| {
                     errno = Errno.translateError(err);
@@ -2331,9 +2373,9 @@ fn wasi_path_create_directory(userdata: ?*anyopaque, module: *ModuleInstance, pa
         if (context.fdLookup(fd_dir_wasi, &errno)) |fd_info| {
             if (Helpers.getMemorySlice(module, path_mem_offset, path_mem_length, &errno)) |path| {
                 if (context.hasPathAccess(fd_info, path, &errno)) {
-                    const S = std.os.linux.S;
-                    const mode: std.os.mode_t = if (builtin.os.tag == .windows) undefined else S.IRWXU | S.IRWXG | S.IROTH;
-                    std.os.mkdirat(fd_info.fd, path, mode) catch |err| {
+                    const S = std.posix.S;
+                    const mode: std.posix.mode_t = if (builtin.os.tag == .windows) undefined else S.IRWXU | S.IRWXG | S.IROTH;
+                    std.posix.mkdirat(fd_info.fd, path, mode) catch |err| {
                         errno = Errno.translateError(err);
                     };
                 }
@@ -2358,15 +2400,17 @@ fn wasi_path_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params
         if (context.fdLookup(fd_dir_wasi, &errno)) |fd_info| {
             if (Helpers.getMemorySlice(module, path_mem_offset, path_mem_length, &errno)) |path| {
                 if (context.hasPathAccess(fd_info, path, &errno)) {
-                    var flags: u32 = std.os.O.RDONLY;
+                    var flags: std.posix.O = .{
+                        .ACCMODE = .RDONLY,
+                    };
                     if (lookup_flags.symlink_follow == false) {
-                        flags |= std.os.O.NOFOLLOW;
+                        flags.NOFOLLOW = true;
                     }
 
-                    const mode: std.os.mode_t = if (builtin.os.tag != .windows) 644 else undefined;
+                    const mode: std.posix.mode_t = if (builtin.os.tag != .windows) 644 else undefined;
 
-                    if (std.os.openat(fd_info.fd, path, flags, mode)) |fd_opened| {
-                        defer std.os.close(fd_opened);
+                    if (std.posix.openat(fd_info.fd, path, flags, mode)) |fd_opened| {
+                        defer std.posix.close(fd_opened);
 
                         const stat: std.os.wasi.filestat_t = if (builtin.os.tag == .windows) Helpers.filestatGetWindows(fd_opened, &errno) else Helpers.filestatGetPosix(fd_opened, &errno);
                         if (errno == .SUCCESS) {
@@ -2436,7 +2480,7 @@ fn wasi_path_remove_directory(userdata: ?*anyopaque, module: *ModuleInstance, pa
                 if (context.hasPathAccess(fd_info, path, &errno)) {
                     var static_path_buffer: [std.fs.MAX_PATH_BYTES * 2]u8 = undefined;
                     if (Helpers.resolvePath(fd_info, path, &static_path_buffer, &errno)) |resolved_path| {
-                        std.os.unlinkat(FD_OS_INVALID, resolved_path, std.os.AT.REMOVEDIR) catch |err| {
+                        std.posix.unlinkat(FD_OS_INVALID, resolved_path, std.posix.AT.REMOVEDIR) catch |err| {
                             errno = Errno.translateError(err);
                         };
 
@@ -2492,7 +2536,7 @@ fn wasi_path_symlink(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]
                                     }
                                 }
                             } else {
-                                std.os.symlinkat(link_contents, fd_info.fd, link_path) catch |err| {
+                                std.posix.symlinkat(link_contents, fd_info.fd, link_path) catch |err| {
                                     errno = Errno.translateError(err);
                                 };
                             }
@@ -2521,7 +2565,7 @@ fn wasi_path_unlink_file(userdata: ?*anyopaque, module: *ModuleInstance, params:
                 if (context.hasPathAccess(fd_info, path, &errno)) {
                     var static_path_buffer: [std.fs.MAX_PATH_BYTES * 2]u8 = undefined;
                     if (Helpers.resolvePath(fd_info, path, &static_path_buffer, &errno)) |resolved_path| {
-                        std.os.unlinkat(FD_OS_INVALID, resolved_path, 0) catch |err| {
+                        std.posix.unlinkat(FD_OS_INVALID, resolved_path, 0) catch |err| {
                             errno = Errno.translateError(err);
                         };
 

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -1543,7 +1543,7 @@ const Helpers = struct {
 
         var dirent_buffer: [1024]u8 align(@alignOf(dirent_t)) = undefined;
         var unused_seek: i64 = 0;
-        const rc = std.c.darwin.__getdirentries64(fd_info.fd, &dirent_buffer, dirent_buffer.len, &unused_seek);
+        const rc = std.c.__getdirentries64(fd_info.fd, &dirent_buffer, dirent_buffer.len, &unused_seek);
         errno.* = switch (std.posix.errno(rc)) {
             .SUCCESS => .SUCCESS,
             .BADF => .BADF,
@@ -1568,7 +1568,7 @@ const Helpers = struct {
 
             // TODO length should be (d_reclen - 2 - offsetof(dirent64, d_name))
             // const filename: []u8 = std.mem.sliceTo(@ptrCast([*:0]u8, &dirent_entry.d_name), 0);
-            const filename: []u8 = @as([*]u8, @ptrCast(&dirent_entry.name))[0..dirent_entry.d_namlen];
+            const filename: []u8 = @as([*]u8, @ptrCast(&dirent_entry.name))[0..dirent_entry.namlen];
 
             const filetype: std.os.wasi.filetype_t = switch (dirent_entry.type) {
                 std.c.DT.UNKNOWN => .UNKNOWN,
@@ -1589,7 +1589,7 @@ const Helpers = struct {
             };
 
             fd_info.dir_entries.append(WasiDirEntry{
-                .inode = dirent_entry.d_ino,
+                .inode = dirent_entry.ino,
                 .filetype = filetype,
                 .filename = filename_duped,
             }) catch |err| {

--- a/src/zig-stable-array/stable_array.zig
+++ b/src/zig-stable-array/stable_array.zig
@@ -209,9 +209,9 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
                     if (comptime builtin.target.isDarwin()) {
                         const MADV_DONTNEED = 4;
                         const err: c_int = darwin.madvise(addr, bytes_to_free, MADV_DONTNEED);
-                        switch (@as(os.darwin.E, @enumFromInt(err))) {
-                            os.E.INVAL => unreachable,
-                            os.E.NOMEM => unreachable,
+                        switch (@as(std.posix.E, @enumFromInt(err))) {
+                            std.posix.E.INVAL => unreachable,
+                            std.posix.E.NOMEM => unreachable,
                             else => {},
                         }
                     } else {

--- a/src/zig-stable-array/stable_array.zig
+++ b/src/zig-stable-array/stable_array.zig
@@ -215,7 +215,7 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
                             else => {},
                         }
                     } else {
-                        os.madvise(addr, bytes_to_free, std.c.MADV.DONTNEED) catch unreachable;
+                        std.posix.madvise(addr, bytes_to_free, std.c.MADV.DONTNEED) catch unreachable;
                     }
                 }
 

--- a/src/zig-stable-array/stable_array.zig
+++ b/src/zig-stable-array/stable_array.zig
@@ -294,6 +294,7 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
                     const map: std.c.MAP = .{
                         .ANONYMOUS = true,
                         .TYPE = .PRIVATE,
+                        .FIXED = true,
                     };
                     const fd: std.posix.fd_t = -1;
                     const offset: usize = 0;

--- a/src/zig-stable-array/stable_array.zig
+++ b/src/zig-stable-array/stable_array.zig
@@ -268,7 +268,7 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
                             .ANONYMOUS = true,
                             .TYPE = .PRIVATE,
                         };
-                        const fd: os.fd_t = -1;
+                        const fd: std.posix.fd_t = -1;
                         const offset: usize = 0;
                         const slice = try std.posix.mmap(null, self.max_virtual_alloc_bytes, prot, map, fd, offset);
                         self.items.ptr = @alignCast(@ptrCast(slice.ptr));

--- a/src/zig-stable-array/stable_array.zig
+++ b/src/zig-stable-array/stable_array.zig
@@ -61,7 +61,7 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
             self.items.len += items.len;
 
             mem.copyBackwards(T, self.items[i + items.len .. self.items.len], self.items[i .. self.items.len - items.len]);
-            mem.copy(T, self.items[i .. i + items.len], items);
+            @memcpy(self.items[i .. i + items.len], items);
         }
 
         pub fn replaceRange(self: *Self, start: usize, len: usize, new_items: []const T) !void {
@@ -69,15 +69,15 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
             const range = self.items[start..after_range];
 
             if (range.len == new_items.len)
-                mem.copy(T, range, new_items)
+                @memcpy(range, new_items)
             else if (range.len < new_items.len) {
                 const first = new_items[0..range.len];
                 const rest = new_items[range.len..];
 
-                mem.copy(T, range, first);
+                @memcpy(range, first);
                 try self.insertSlice(after_range, rest);
             } else {
-                mem.copy(T, range, new_items);
+                @memcpy(range, new_items);
                 const after_subrange = start + new_items.len;
 
                 for (self.items[after_range..], 0..) |item, i| {
@@ -108,7 +108,7 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
             const new_len = old_len + items.len;
             assert(new_len <= self.capacity);
             self.items.len = new_len;
-            mem.copy(T, self.items[old_len..], items);
+            @memcpy(self.items[old_len..], items);
         }
 
         pub fn appendNTimes(self: *Self, value: T, n: usize) !void {
@@ -243,7 +243,7 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
                     var slice: []align(mem.page_size) const u8 = undefined;
                     slice.ptr = @alignCast(@as([*]u8, @ptrCast(self.items.ptr)));
                     slice.len = self.max_virtual_alloc_bytes;
-                    os.munmap(slice);
+                    std.posix.munmap(slice);
                 }
             }
 
@@ -264,10 +264,13 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
                         self.items.len = 0;
                     } else {
                         const prot: u32 = std.c.PROT.READ | std.c.PROT.WRITE;
-                        const map: u32 = std.c.MAP.PRIVATE | std.c.MAP.ANONYMOUS;
+                        const map: std.c.MAP = .{
+                            .ANONYMOUS = true,
+                            .TYPE = .PRIVATE,
+                        };
                         const fd: os.fd_t = -1;
                         const offset: usize = 0;
-                        var slice = try os.mmap(null, self.max_virtual_alloc_bytes, prot, map, fd, offset);
+                        const slice = try std.posix.mmap(null, self.max_virtual_alloc_bytes, prot, map, fd, offset);
                         self.items.ptr = @alignCast(@ptrCast(slice.ptr));
                         self.items.len = 0;
                     }

--- a/src/zig-stable-array/stable_array.zig
+++ b/src/zig-stable-array/stable_array.zig
@@ -203,9 +203,9 @@ pub fn StableArrayAligned(comptime T: type, comptime alignment: u29) type {
                     const addr: usize = @intFromPtr(self.items.ptr) + new_capacity_bytes;
                     w.VirtualFree(@as(w.PVOID, @ptrFromInt(addr)), bytes_to_free, w.MEM_DECOMMIT);
                 } else {
-                    var base_addr: usize = @intFromPtr(self.items.ptr);
-                    var offset_addr: usize = base_addr + new_capacity_bytes;
-                    var addr: [*]align(mem.page_size) u8 = @ptrFromInt(offset_addr);
+                    const base_addr: usize = @intFromPtr(self.items.ptr);
+                    const offset_addr: usize = base_addr + new_capacity_bytes;
+                    const addr: [*]align(mem.page_size) u8 = @ptrFromInt(offset_addr);
                     if (comptime builtin.target.isDarwin()) {
                         const MADV_DONTNEED = 4;
                         const err: c_int = darwin.madvise(addr, bytes_to_free, MADV_DONTNEED);

--- a/test/main.zig
+++ b/test/main.zig
@@ -207,7 +207,7 @@ fn parseVal(obj: std.json.ObjectMap) !TaggedVal {
 
         fn parseF32(str: []const u8) !f32 {
             if (std.mem.startsWith(u8, str, "nan:")) {
-                return std.math.nan_f32; // don't differentiate between arithmetic/canonical nan
+                return std.math.nan(f32); // don't differentiate between arithmetic/canonical nan
             } else {
                 const int = try std.fmt.parseInt(u32, str, 10);
                 return @as(f32, @bitCast(int));
@@ -216,7 +216,7 @@ fn parseVal(obj: std.json.ObjectMap) !TaggedVal {
 
         fn parseF64(str: []const u8) !f64 {
             if (std.mem.startsWith(u8, str, "nan:")) {
-                return std.math.nan_f64; // don't differentiate between arithmetic/canonical nan
+                return std.math.nan(f64); // don't differentiate between arithmetic/canonical nan
             } else {
                 const int = try std.fmt.parseInt(u64, str, 10);
                 return @as(f64, @bitCast(int));

--- a/test/main.zig
+++ b/test/main.zig
@@ -1480,7 +1480,7 @@ pub fn main() !void {
             needs_regen = true;
         } else {
             std.fs.cwd().access(suite_path, .{ .mode = .read_only }) catch |e| {
-                if (e == std.os.AccessError.FileNotFound) {
+                if (e == std.posix.AccessError.FileNotFound) {
                     needs_regen = true;
                 }
             };
@@ -1533,6 +1533,6 @@ pub fn main() !void {
     }
 
     if (did_all_succeed == false) {
-        std.os.exit(1);
+        std.process.exit(1);
     }
 }


### PR DESCRIPTION
I took the liberty of updating the codebase to work with zig 0.12.0. There were a lot of changes due to std.os being largely moved to std.posix and some methods removed.

I've run the tests on each of the following:

| OS | x86_64 | Aarch64 |
| ---  | --- | --- |
| Linux | 100% | 100% |
| MacOS | N/A | 100% |
| Windows | 100% | 1 failed [^1] |

I know you have your #37 PR in progress. If you want to hold off on merging this, I would be happy to handle any merge conflicts that arise due to that PR.

[^1]: Windows Aarch64 has wasi `dangling_symlink` test failing on both 0.11.0 and 0.12.0.