### PR TITLE
optimize branch table immediates

### DIFF
--- a/src/instance.zig
+++ b/src/instance.zig
@@ -107,9 +107,9 @@ pub const DebugTrace = struct {
         }
     }
 
-    pub fn traceFunction(module_instance: *const ModuleInstance, indent: u32, func_index: u32) void {
+    pub fn traceFunction(module_instance: *const ModuleInstance, indent: u32, func_index: usize) void {
         if (shouldTraceFunctions()) {
-            const func_name_index: u32 = func_index + @as(u32, @intCast(module_instance.module_def.imports.functions.items.len));
+            const func_name_index: usize = func_index + module_instance.module_def.imports.functions.items.len;
 
             const name_section: *const NameCustomSection = &module_instance.module_def.name_section;
             const module_name = name_section.getModuleName();

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -84,9 +84,9 @@ const DebugTraceStackVM = struct {
 };
 
 const FunctionInstance = struct {
-    type_def_index: u32,
-    def_index: u32,
-    instructions_begin: u32,
+    type_def_index: usize,
+    def_index: usize,
+    instructions_begin: usize,
     local_types: std.ArrayList(ValType),
 };
 
@@ -1061,7 +1061,7 @@ const InstructionFuncs = struct {
 
             return FuncCallData{
                 .code = module_instance.module_def.code.instructions.items.ptr,
-                .continuation = func.instructions_begin,
+                .continuation = @intCast(func.instructions_begin),
             };
         }
 
@@ -1721,8 +1721,12 @@ const InstructionFuncs = struct {
 
     fn op_Branch_Table(pc: u32, code: [*]const Instruction, stack: *Stack) anyerror!void {
         try debugPreamble("Branch_Table", pc, code, stack);
-        const immediates: *const BranchTableImmediates = &stack.topFrame().module_instance.module_def.code.branch_table.items[code[pc].immediate.Index];
-        const table: []const u32 = immediates.label_ids.items;
+        const module_instance: *const ModuleInstance = stack.topFrame().module_instance;
+        const all_branch_table_immediates: []const BranchTableImmediates = stack.topFrame().module_instance.module_def.code.branch_table.items;
+        const immediate_index = code[pc].immediate.Index;
+
+        const immediates: BranchTableImmediates = all_branch_table_immediates[immediate_index];
+        const table: []const u32 = immediates.getLabelIds(module_instance.module_def.*);
 
         const label_index = stack.popI32();
         const label_id: u32 = if (label_index >= 0 and label_index < table.len) table[@as(usize, @intCast(label_index))] else immediates.fallback_id;
@@ -5399,7 +5403,7 @@ pub const StackVM = struct {
             const name_section: *const NameCustomSection = &frame.module_instance.module_def.name_section;
             const module_name = name_section.getModuleName();
 
-            const func_name_index: u32 = frame.func.def_index + @as(u32, @intCast(frame.module_instance.module_def.imports.functions.items.len));
+            const func_name_index: usize = frame.func.def_index + frame.module_instance.module_def.imports.functions.items.len;
             const function_name = name_section.findFunctionName(func_name_index);
 
             try writer.print("{}: {s}!{s}\n", .{ reverse_index, module_name, function_name });
@@ -5436,11 +5440,11 @@ pub const StackVM = struct {
         }
 
         try self.stack.pushFrame(&func, module, param_types, func.local_types.items, func_type.calcNumReturns());
-        try self.stack.pushLabel(@as(u32, @intCast(return_types.len)), func_def.continuation);
+        try self.stack.pushLabel(@as(u32, @intCast(return_types.len)), @intCast(func_def.continuation));
 
         DebugTrace.traceFunction(module, self.stack.num_frames, func.def_index);
 
-        try InstructionFuncs.run(func.instructions_begin, module.module_def.code.instructions.items.ptr, &self.stack);
+        try InstructionFuncs.run(@intCast(func.instructions_begin), module.module_def.code.instructions.items.ptr, &self.stack);
 
         if (returns_slice.len > 0) {
             var index: i32 = @as(i32, @intCast(returns_slice.len - 1));


### PR DESCRIPTION
* now all label IDs are stored in one big array, and the immediates just look up into this array