### PR TITLE
Optimization passes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,9 +18,13 @@ const ExeOpts = struct {
 
 pub fn build(b: *Build) void {
     const enable_metering = b.option(bool, "meter", "Enable metering") orelse false;
+    const enable_debug_trace = b.option(bool, "debug_trace", "Enable debug tracing feature") orelse false;
+    const enable_debug_trap = b.option(bool, "debug_trap", "Enable debug trap features") orelse false;
 
     const options = b.addOptions();
     options.addOption(bool, "enable_metering", enable_metering);
+    options.addOption(bool, "enable_debug_trace", enable_debug_trace);
+    options.addOption(bool, "enable_debug_trap", enable_debug_trap);
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});

--- a/optimize.md
+++ b/optimize.md
@@ -1,0 +1,13 @@
+== Failed Optimizations ==
+
+* Giving locals their own stack space separate from values. The idea here was to save
+  some perf on push/pop of call frames so that we wouldn't have to copy the return values
+  back to the appropriate place. But since the wasm calling convention is to pass params
+  via the stack, you'd have to copy them elsewhere anyway, defeating the point of 
+  the optimization anyway, which is to avoid copying values around.
+
+* Instruction stream. Instead of having an array of structs that contain opcode + immediates,
+  have a byte stream of opcodes and immediates where you don't have to pay for the extra memory
+  of the immediates if you don't need them. But it turns out that a lot of instructions 
+  use immediates anyway and the overhead of fetching them out of the stream is more
+  expensive than just paying for the cache hits. Overall memory is 

--- a/run/main.zig
+++ b/run/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const bytebox = @import("bytebox");
+const config = bytebox.config;
 const wasi = bytebox.wasi;
 
 const Val = bytebox.Val;
@@ -105,7 +106,12 @@ fn parseCmdOpts(args: [][]const u8, env_buffer: *std.ArrayList([]const u8), dir_
             arg_index += 1;
             if (getArgSafe(arg_index, args)) |mode_str| {
                 if (bytebox.DebugTrace.parseMode(mode_str)) |mode| {
-                    opts.trace = mode;
+                    if (config.enable_debug_trace == false) {
+                        log.err("Bytebox was not compiled with -Ddebug_trace=true. Enable this compile time flag if you want to enable tracing at runtime.", .{});
+                        opts.invalid_arg = mode_str;
+                    } else {
+                        opts.trace = mode;
+                    }
                 } else {
                     opts.invalid_arg = mode_str;
                 }
@@ -169,6 +175,8 @@ fn printHelp(args: [][]const u8) void {
         \\       * none (default)
         \\       * function
         \\       * instruction
+        \\     Note that this requires bytebox to be compiled with the flag -Ddebug_trace=true,
+        \\     which is off by default for performance reasons.
         \\
         \\
     ;

--- a/src/core.zig
+++ b/src/core.zig
@@ -4,6 +4,7 @@ const def = @import("definition.zig");
 const inst = @import("instance.zig");
 const vm_stack = @import("vm_stack.zig");
 const vm_register = @import("vm_register.zig");
+pub const config = @import("config");
 pub const wasi = @import("wasi.zig");
 
 pub const LogLevel = common.LogLevel;

--- a/src/definition.zig
+++ b/src/definition.zig
@@ -809,41 +809,17 @@ pub const TablePairImmediates = extern struct {
 
 pub const BlockImmediates = extern struct {
     block_type: BlockType,
+    num_returns: u16,
     block_value: BlockTypeValue,
-    num_returns: u32,
     continuation: u32,
 };
 
 pub const IfImmediates = extern struct {
     block_type: BlockType,
+    num_returns: u16,
     block_value: BlockTypeValue,
-    num_returns: u32,
     else_continuation: u32,
     end_continuation: u32,
-};
-
-// const InstructionImmediatesTypes = enum(u8) {
-//     Void,
-//     ValType,
-//     ValueI32,
-//     ValueF32,
-//     ValueI64,
-//     ValueF64,
-//     ValueVec,
-//     Index,
-//     LabelId,
-//     MemoryOffset,
-//     MemoryOffsetAndLane,
-//     Block,
-//     CallIndirect,
-//     TablePair,
-//     If,
-//     VecShuffle16,
-// };
-
-pub const AlignedBytes = struct {
-    bytes: []align(1) const u8,
-    alignment: usize,
 };
 
 pub const InstructionImmediates = extern union {
@@ -864,6 +840,10 @@ pub const InstructionImmediates = extern union {
     If: IfImmediates,
     VecShuffle16: [16]u8,
 };
+
+comptime {
+    std.debug.assert(@sizeOf(InstructionImmediates) == 16);
+}
 
 pub const Instruction = struct {
     opcode: Opcode,
@@ -901,7 +881,7 @@ pub const Instruction = struct {
                     block_value = BlockTypeValue{ .ValType = valtype };
                 }
 
-                const num_returns: u32 = @as(u32, @intCast(block_value.getBlocktypeReturnTypes(block_type, _module).len));
+                const num_returns: u16 = @intCast(block_value.getBlocktypeReturnTypes(block_type, _module).len);
 
                 return InstructionImmediates{
                     .Block = BlockImmediates{

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -3,6 +3,7 @@ const AllocError = std.mem.Allocator.Error;
 
 const builtin = @import("builtin");
 
+const config = @import("config");
 const metering = @import("metering.zig");
 
 const common = @import("common.zig");
@@ -70,6 +71,7 @@ pub const DebugTrace = struct {
     };
 
     pub fn setMode(new_mode: Mode) void {
+        std.debug.assert(config.enable_debug_trace == true);
         mode = new_mode;
     }
 
@@ -86,11 +88,11 @@ pub const DebugTrace = struct {
     }
 
     pub fn shouldTraceFunctions() bool {
-        return mode == .Function;
+        return config.enable_debug_trace and mode == .Function;
     }
 
     pub fn shouldTraceInstructions() bool {
-        return mode == .Instruction;
+        return config.enable_debug_trace and mode == .Instruction;
     }
 
     pub fn printIndent(indent: u32) void {

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 
+const config = @import("config");
+
 const common = @import("common.zig");
 const StableArray = common.StableArray;
 
@@ -75,7 +77,7 @@ const metering = @import("metering.zig");
 
 const DebugTraceStackVM = struct {
     fn traceInstruction(instruction_name: []const u8, pc: u32, stack: *const Stack) void {
-        if (DebugTrace.shouldTraceInstructions()) {
+        if (config.enable_debug_trace and DebugTrace.shouldTraceInstructions()) {
             const frame: *const CallFrame = stack.topFrame();
             const name_section: *const NameCustomSection = &frame.module_instance.module_def.name_section;
             const module_name = name_section.getModuleName();
@@ -1596,12 +1598,14 @@ const InstructionFuncs = struct {
             }
         }
 
-        if (root_stackvm.debug_state) |*debug_state| {
-            if (debug_state.trap_counter > 0) {
-                debug_state.trap_counter -= 1;
-                if (debug_state.trap_counter == 0) {
-                    debug_state.pc = pc;
-                    return error.TrapDebug;
+        if (config.enable_debug_trap) {
+            if (root_stackvm.debug_state) |*debug_state| {
+                if (debug_state.trap_counter > 0) {
+                    debug_state.trap_counter -= 1;
+                    if (debug_state.trap_counter == 0) {
+                        debug_state.pc = pc;
+                        return error.TrapDebug;
+                    }
                 }
             }
         }

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -2400,7 +2400,6 @@ fn wasi_path_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params
         if (context.fdLookup(fd_dir_wasi, &errno)) |fd_info| {
             if (Helpers.getMemorySlice(module, path_mem_offset, path_mem_length, &errno)) |path| {
                 if (context.hasPathAccess(fd_info, path, &errno)) {
-
                     if (builtin.os.tag == .windows) {
                         const dir = std.fs.Dir{
                             .fd = fd_info.fd,
@@ -2409,14 +2408,13 @@ fn wasi_path_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params
                             defer file.close();
 
                             const stat: std.os.wasi.filestat_t = Helpers.filestatGetWindows(file.handle, &errno);
-                        if (errno == .SUCCESS) {
-                            Helpers.writeFilestatToMemory(&stat, filestat_out_mem_offset, module, &errno);
-                        }
+                            if (errno == .SUCCESS) {
+                                Helpers.writeFilestatToMemory(&stat, filestat_out_mem_offset, module, &errno);
+                            }
                         } else |err| {
                             errno = Errno.translateError(err);
                         }
                     } else {
-
                         var flags: std.posix.O = .{
                             .ACCMODE = .RDONLY,
                         };

--- a/test/wasm/main.zig
+++ b/test/wasm/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const bytebox = @import("bytebox");
+const config = bytebox.config;
 const ValType = bytebox.ValType;
 const Val = bytebox.Val;
 const TaggedVal = bytebox.TaggedVal;
@@ -1358,7 +1359,9 @@ pub fn main() !void {
             print("found test filter: {s}\n", .{opts.test_filter_or_null.?});
         } else if (strcmp("--trace", arg)) {
             args_index += 1;
-            if (bytebox.DebugTrace.parseMode(args[args_index])) |mode| {
+            if (config.enable_debug_trace == false) {
+                print("Debug tracing must be enabled at compile time -Ddebug_trace=true\n", .{});
+            } else if (bytebox.DebugTrace.parseMode(args[args_index])) |mode| {
                 bytebox.DebugTrace.setMode(mode);
             } else {
                 print("got invalid trace mode '{s}', check help for allowed options", .{args[args_index]});


### PR DESCRIPTION
* New `zig build asm` command to generate assembly for perf analysis
* Gate the debug trace and trap features behind a compile-time option. Most users probably don't care about this and it has a non-trivial impact on perf.
* Fix instruction immediates regressing to 32 bytes. When they were changed to be extern structs, the ordering started to matter. Now there's a comptime check to make sure they're always 16 bytes.
* Embed param/return count in function instance to avoid an extra pointer hop.
* Minor optimization to use `@memset` to initialize locals since the default values are always 0 anyway.