### PR TITLE
Host Function Errors

### DIFF
--- a/src/bytebox.h
+++ b/src/bytebox.h
@@ -66,6 +66,13 @@ typedef struct bb_module_instance bb_module_instance;
 typedef struct bb_import_package bb_import_package;
 
 typedef void bb_host_function(void* userdata, bb_module_instance* module, const bb_val* params, bb_val* returns);
+struct bb_import_function
+{
+	bb_host_function* callback;
+	void* userdata;
+};
+typedef struct bb_import_function bb_import_function;
+
 typedef void* bb_wasm_memory_resize(void* mem, size_t new_size_bytes, size_t old_size_bytes, void* userdata);
 typedef void bb_wasm_memory_free(void* mem, size_t size_bytes, void* userdata);
 
@@ -148,7 +155,7 @@ bb_slice bb_module_definition_get_custom_section(const bb_module_definition* def
 
 bb_import_package* bb_import_package_init(const char* name);
 void bb_import_package_deinit(bb_import_package* package);	  // only deinit when all module_instances using the package have been destroyed
-bb_error bb_import_package_add_function(bb_import_package* package, bb_host_function* func, const char* export_name, const bb_valtype* params, size_t num_params, const bb_valtype* returns, size_t num_returns, void* userdata);
+bb_error bb_import_package_add_function(bb_import_package* package, const char* export_name, const bb_valtype* params, size_t num_params, const bb_valtype* returns, size_t num_returns, bb_import_function* userdata);
 bb_error bb_import_package_add_memory(bb_import_package* package, const bb_wasm_memory_config* config, const char* export_name, uint32_t min_pages, uint32_t max_pages);
 
 void bb_set_debug_trace_mode(bb_debug_trace_mode mode);

--- a/src/cffi.zig
+++ b/src/cffi.zig
@@ -42,7 +42,7 @@ const CModuleDefinitionInitOpts = extern struct {
     debug_name: ?[*:0]u8,
 };
 
-const CHostFunction = *const fn (userdata: ?*anyopaque, module: *core.ModuleInstance, params: [*]const Val, returns: [*]Val) void;
+const CHostFunction = *const fn (userdata: ?*anyopaque, module: *core.ModuleInstance, params: [*]const Val, returns: [*]Val) error{}!void;
 
 const CWasmMemoryConfig = extern struct {
     resize: ?core.WasmMemoryResizeFunction,

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -358,7 +358,10 @@ const ImportType = enum(u8) {
     Wasm,
 };
 
-const HostFunctionCallback = *const fn (userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void;
+const root = @import("root");
+const HostFunctionErrors = if (@hasDecl(root, "HostFunctionErrors")) root.HostFunctionErrors else error{};
+
+const HostFunctionCallback = *const fn (userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) HostFunctionErrors!void;
 
 const HostFunction = struct {
     userdata: ?*anyopaque,

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -359,9 +359,9 @@ const ImportType = enum(u8) {
 };
 
 const root = @import("root");
-const HostFunctionErrors = if (@hasDecl(root, "HostFunctionErrors")) root.HostFunctionErrors else error{};
+pub const HostFunctionError = if (@hasDecl(root, "HostFunctionError")) root.HostFunctionError else error{};
 
-const HostFunctionCallback = *const fn (userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) HostFunctionErrors!void;
+const HostFunctionCallback = *const fn (userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) HostFunctionError!void;
 
 const HostFunction = struct {
     userdata: ?*anyopaque,

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -55,6 +55,7 @@ const UnlinkableError = inst.UnlinkableError;
 const UninstantiableError = inst.UninstantiableError;
 const ExportError = inst.ExportError;
 const TrapError = inst.TrapError;
+const HostFunctionError = inst.HostFunctionError;
 const DebugTrace = inst.DebugTrace;
 const TableInstance = inst.TableInstance;
 const MemoryInstance = inst.MemoryInstance;
@@ -1064,7 +1065,7 @@ const InstructionFuncs = struct {
             };
         }
 
-        fn callImport(pc: u32, stack: *Stack, func: *const FunctionImport) TrapError!FuncCallData {
+        fn callImport(pc: u32, stack: *Stack, func: *const FunctionImport) (TrapError || HostFunctionError)!FuncCallData {
             switch (func.data) {
                 .Host => |data| {
                     const params_len: u32 = @as(u32, @intCast(data.func_def.getParams().len));

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -1077,7 +1077,7 @@ const InstructionFuncs = struct {
 
                         DebugTrace.traceHostFunction(module, stack.num_frames + 1, func.name);
 
-                        data.callback(data.userdata, module, params.ptr, returns_temp.ptr);
+                        try data.callback(data.userdata, module, params.ptr, returns_temp.ptr);
 
                         stack.num_values = (stack.num_values - params_len) + returns_len;
                         const returns_dest = stack.values[stack.num_values - returns_len .. stack.num_values];
@@ -5515,7 +5515,7 @@ pub const StackVM = struct {
             .Host => |data| {
                 DebugTrace.traceHostFunction(module, 1, func_import.name);
 
-                data.callback(data.userdata, module, params, returns);
+                try data.callback(data.userdata, module, params, returns);
             },
             .Wasm => |data| {
                 var import_instance: *ModuleInstance = data.module_instance;

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -1700,7 +1700,9 @@ const Helpers = struct {
     }
 };
 
-fn wasi_proc_exit(_: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, _: [*]Val) void {
+const WasiError = error{};
+
+fn wasi_proc_exit(_: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, _: [*]Val) WasiError!void {
     const raw_exit_code = params[0].I32;
 
     if (raw_exit_code >= 0 and raw_exit_code < std.math.maxInt(u8)) {
@@ -1711,27 +1713,27 @@ fn wasi_proc_exit(_: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, _: [
     }
 }
 
-fn wasi_args_sizes_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_args_sizes_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     const context = WasiContext.fromUserdata(userdata);
     Helpers.stringsSizesGet(module, context.argv, params, returns);
 }
 
-fn wasi_args_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_args_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     const context = WasiContext.fromUserdata(userdata);
     Helpers.stringsGet(module, context.argv, params, returns);
 }
 
-fn wasi_environ_sizes_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_environ_sizes_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     const context = WasiContext.fromUserdata(userdata);
     Helpers.stringsSizesGet(module, context.env, params, returns);
 }
 
-fn wasi_environ_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_environ_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     const context = WasiContext.fromUserdata(userdata);
     Helpers.stringsGet(module, context.env, params, returns);
 }
 
-fn wasi_clock_res_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_clock_res_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const system_clockid: i32 = Helpers.convertClockId(params[0].I32);
@@ -1774,7 +1776,7 @@ fn wasi_clock_res_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const 
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_clock_time_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_clock_time_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const system_clockid: i32 = Helpers.convertClockId(params[0].I32);
@@ -1844,7 +1846,7 @@ fn wasi_clock_time_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_datasync(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_datasync(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     const context = WasiContext.fromUserdata(userdata);
     const fd_wasi = @as(u32, @bitCast(params[0].I32));
 
@@ -1859,7 +1861,7 @@ fn fd_wasi_datasync(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const 
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_fdstat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_fdstat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -1883,7 +1885,7 @@ fn fd_wasi_fdstat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_fdstat_set_flags(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_fdstat_set_flags(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -1900,7 +1902,7 @@ fn fd_wasi_fdstat_set_flags(userdata: ?*anyopaque, _: *ModuleInstance, params: [
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_prestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_prestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -1919,7 +1921,7 @@ fn fd_wasi_prestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_prestat_dir_name(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_prestat_dir_name(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -1947,7 +1949,7 @@ fn fd_wasi_prestat_dir_name(userdata: ?*anyopaque, module: *ModuleInstance, para
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_read(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_read(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -1976,7 +1978,7 @@ fn fd_wasi_read(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_readdir(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_readdir(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -1998,7 +2000,7 @@ fn fd_wasi_readdir(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]co
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_renumber(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_renumber(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2010,7 +2012,7 @@ fn fd_wasi_renumber(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const 
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_pread(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_pread(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2040,7 +2042,7 @@ fn fd_wasi_pread(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]cons
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_advise(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_advise(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2084,7 +2086,7 @@ fn fd_wasi_advise(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Va
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_allocate(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_allocate(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2148,7 +2150,7 @@ fn fd_wasi_allocate(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const 
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_close(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_close(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2162,7 +2164,7 @@ fn fd_wasi_close(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -2186,7 +2188,7 @@ fn fd_wasi_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: 
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_filestat_set_size(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_filestat_set_size(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -2206,7 +2208,7 @@ fn fd_wasi_filestat_set_size(userdata: ?*anyopaque, _: *ModuleInstance, params: 
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_filestat_set_times(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_filestat_set_times(userdata: ?*anyopaque, _: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -2238,7 +2240,7 @@ fn fd_wasi_filestat_set_times(userdata: ?*anyopaque, _: *ModuleInstance, params:
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_seek(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_seek(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2290,7 +2292,7 @@ fn fd_wasi_seek(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_tell(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_tell(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -2311,7 +2313,7 @@ fn fd_wasi_tell(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_write(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_write(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2336,7 +2338,7 @@ fn fd_wasi_write(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]cons
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn fd_wasi_pwrite(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn fd_wasi_pwrite(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2362,7 +2364,7 @@ fn fd_wasi_pwrite(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]con
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_path_create_directory(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_path_create_directory(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -2386,7 +2388,7 @@ fn wasi_path_create_directory(userdata: ?*anyopaque, module: *ModuleInstance, pa
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_path_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_path_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const context = WasiContext.fromUserdata(userdata);
@@ -2443,7 +2445,7 @@ fn wasi_path_filestat_get(userdata: ?*anyopaque, module: *ModuleInstance, params
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_path_open(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_path_open(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2481,7 +2483,7 @@ fn wasi_path_open(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]con
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_path_remove_directory(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_path_remove_directory(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2512,7 +2514,7 @@ fn wasi_path_remove_directory(userdata: ?*anyopaque, module: *ModuleInstance, pa
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_path_symlink(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_path_symlink(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2566,7 +2568,7 @@ fn wasi_path_symlink(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_path_unlink_file(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_path_unlink_file(userdata: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     var context = WasiContext.fromUserdata(userdata);
@@ -2597,7 +2599,7 @@ fn wasi_path_unlink_file(userdata: ?*anyopaque, module: *ModuleInstance, params:
     returns[0] = Val{ .I32 = @intFromEnum(errno) };
 }
 
-fn wasi_random_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) void {
+fn wasi_random_get(_: ?*anyopaque, module: *ModuleInstance, params: [*]const Val, returns: [*]Val) WasiError!void {
     var errno = Errno.SUCCESS;
 
     const array_begin_offset: u32 = Helpers.signedCast(u32, params[0].I32, &errno);

--- a/test/cffi/main.c
+++ b/test/cffi/main.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include "bytebox.h"
+
+void magic(void *userdata, bb_module_instance *inst, const bb_val *params, bb_val *returns) {
+  int *data = (int *)userdata;
+
+  returns[0].i32_val = *data;
+}
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    return -1;
+  }
+
+  char *path = argv[2];
+  bb_module_definition_init_opts mod_opts;
+  mod_opts.debug_name = "test-cffi";
+
+  bb_module_definition *mod_def = bb_module_definition_create(mod_opts);
+
+  bb_import_package *imports[1];
+  imports[0] = bb_import_package_init("env");
+  bb_error err;
+
+  int magic_num = 40;
+  bb_valtype magic_returns[1];
+  magic_returns[0] = BB_VALTYPE_I32;
+
+  bb_import_function magic_func;
+  magic_func.callback = &magic;
+  magic_func.userdata = (void *)&magic_num;
+
+  err = bb_import_package_add_function(imports[0], "magic", NULL, 0, magic_returns, 1, &magic_func);
+
+  bb_module_instance *mod_inst = bb_module_instance_create(mod_def);
+
+  bb_module_instance_instantiate_opts inst_opts = {0};
+  inst_opts.packages = imports;
+  inst_opts.num_packages = 1;
+
+  err = bb_module_instance_instantiate(mod_inst, inst_opts);
+  if (err != BB_ERROR_OK) {
+    fprintf(stderr, "Instantiation failed with %d %s\n", err, bb_error_str(err));
+    goto cleanup;
+  }
+
+  bb_func_handle entry;
+  err = bb_module_instance_find_func(mod_inst, "entry", &entry);
+
+  if (err != BB_ERROR_OK) {
+    fprintf(stderr, "Failed to find function 'entry': %d %s\n", err, bb_error_str(err));
+    goto cleanup;
+  }
+
+  bb_module_instance_invoke_opts invoke_opts = {0};
+  bb_val returns[1];
+  err = bb_module_instance_invoke(mod_inst, entry, NULL, 0, &returns, 1, invoke_opts);
+
+  if (err != BB_ERROR_OK) {
+    fprintf(stderr, "Error invoking entry: %d %s\n", err, bb_error_str(err));
+    goto cleanup;
+  }
+
+  if (returns[0].i32_val != 42) {
+    err = -42;
+  } else {
+    err = BB_ERROR_OK;
+  }
+
+cleanup:
+  bb_module_instance_destroy(mod_inst);
+  bb_import_package_deinit(imports[0]);
+  bb_module_definition_destroy(mod_def);
+
+  if (err != BB_ERROR_OK) {
+    return err;
+  }
+  return 0;
+}

--- a/test/cffi/module.zig
+++ b/test/cffi/module.zig
@@ -1,0 +1,5 @@
+extern fn magic() i32;
+export fn entry() i32 {
+    const magic_num = magic();
+    return magic_num + 2;
+}

--- a/test/wasm/main.zig
+++ b/test/wasm/main.zig
@@ -638,31 +638,31 @@ const TestOpts = struct {
 
 fn makeSpectestImports(allocator: std.mem.Allocator) !bytebox.ModuleImportPackage {
     const Functions = struct {
-        fn printI32(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) void {
+        fn printI32(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) error{}!void {
             // std.debug.print("{}", .{params[0].I32});
         }
 
-        fn printI64(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) void {
+        fn printI64(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) error{}!void {
             // std.debug.print("{}", .{params[0].I64});
         }
 
-        fn printF32(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) void {
+        fn printF32(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) error{}!void {
             // std.debug.print("{}", .{params[0].F32});
         }
 
-        fn printF64(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) void {
+        fn printF64(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) error{}!void {
             // std.debug.print("{}", .{params[0].F64});
         }
 
-        fn printI32F32(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) void {
+        fn printI32F32(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) error{}!void {
             // std.debug.print("{} {}", .{ params[0].I32, params[1].F32 });
         }
 
-        fn printF64F64(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) void {
+        fn printF64F64(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) error{}!void {
             // std.debug.print("{} {}", .{ params[0].F64, params[1].F64 });
         }
 
-        fn print(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) void {
+        fn print(_: ?*anyopaque, _: *bytebox.ModuleInstance, _: [*]const Val, _: [*]Val) error{}!void {
             // std.debug.print("\n", .{});
         }
     };


### PR DESCRIPTION
It would be helpful if host functions could fail. We can leverage the `@import("root")` pattern in Zig to allow the host to expose the Error union so that imports can be allowed to fail in host specific ways.

I found this useful for my [Wombat](https://github.com/Southporter/wombat) project as a way to short circuit a host function that doesn't fit one of the TrapError options. I figured this might be a pattern that others might want.