### PR TITLE
compress FuncRef into 8 bytes

### DIFF
--- a/run/main.zig
+++ b/run/main.zig
@@ -285,7 +285,7 @@ pub fn main() !void {
         return RunErrors.MissingFunction;
     };
 
-    const func_export: bytebox.FunctionExport = module_def.getFunctionExport(func_handle);
+    const func_export: bytebox.FunctionExport = module_def.getFunctionExport(func_handle).?;
 
     const num_params: usize = invoke_args.len;
     if (func_export.params.len != num_params) {

--- a/src/Stack.zig
+++ b/src/Stack.zig
@@ -32,6 +32,8 @@ pub const FunctionInstance = struct {
 
     max_values: u32,
     max_labels: u32,
+
+    module: *ModuleInstance,
 };
 
 pub const Label = struct {

--- a/src/bytebox.h
+++ b/src/bytebox.h
@@ -104,7 +104,6 @@ typedef struct bb_module_instance_invoke_opts bb_module_instance_invoke_opts;
 struct bb_func_handle
 {
 	uint32_t index;
-	uint32_t type;
 };
 typedef struct bb_func_handle bb_func_handle;
 

--- a/src/opcode.zig
+++ b/src/opcode.zig
@@ -958,7 +958,7 @@ const ConversionTables = struct {
         Opcode.Branch_If, // 0x0D
         Opcode.Branch_Table, // 0x0E
         Opcode.Return, // 0x0F
-        Opcode.Invalid, // 0x10 (WasmOpcode.Call)
+        Opcode.Call_Local, // 0x10 (WasmOpcode.Call)
         Opcode.Call_Indirect, // 0x11
         Opcode.Invalid, // 0x12
         Opcode.Invalid, // 0x13

--- a/src/vm_register.zig
+++ b/src/vm_register.zig
@@ -51,6 +51,7 @@ const TablePairImmediates = def.TablePairImmediates;
 const Val = def.Val;
 const ValType = def.ValType;
 const TaggedVal = def.TaggedVal;
+const FuncRef = def.FuncRef;
 
 const inst = @import("instance.zig");
 const VM = inst.VM;
@@ -1167,6 +1168,12 @@ pub const RegisterVM = struct {
         _ = module;
         _ = local_func_index;
         return &dummy_func_type_def;
+    }
+
+    pub fn resolveFuncRef(vm: *VM, func: FuncRef) FuncRef {
+        _ = vm;
+        _ = func;
+        return FuncRef.nullRef();
     }
 
     pub fn compile(vm: *RegisterVM, module_def: ModuleDefinition) AllocError!void {


### PR DESCRIPTION
* Function imports now have a local function trampoline that exists to simplify the function lookup code and unifies references to local/import functions. Now instead of handling special cases and adding/subtracting function indices all the time, the code can simply reference the local function and it will immediately trampoline to the import using the existing call import logic.
* Previously FuncRef stored a pointer to the module (8 bytes) and an index (4 bytes). This was because there was no way to uniformly refer to functions since they could either be local or an import. Now that import trampolines exist, FuncRefs can store a pointer directly to the VM- defined function instance, which stores all the information needed for calling it.
* Instead of doing some halfway module pointer fixup, FuncRefs exist in either a definition state with an index, or an instance state with a valid pointer, and they are explicitly resolved at instantiation time.
* Tweaked funcref/externref null handling to be consistent between definition and instance states.