### PR TITLE
zig build tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           zig build -Dvm_kind=${{ matrix.stack_kind }}
 
+      - name: Bench
+        run: |
+          zig build bench -Dvm_kind=${{ matrix.stack_kind }} -Doptimize=ReleaseFast
+
       - name: 32-bit builds
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
* Only build bytebox lib by default, bench and dependencies are now only build on-demand. This saves a bunch of time while iterating on code.