### PR TITLE
compress immediates to 8 bytes

### DIFF
--- a/src/vm_register.zig
+++ b/src/vm_register.zig
@@ -675,7 +675,10 @@ const ModuleIR = struct {
                 .I64 => Val{ .I64 = instruction.immediate.ValueI64 },
                 .F32 => Val{ .F32 = instruction.immediate.ValueF32 },
                 .F64 => Val{ .F64 = instruction.immediate.ValueF64 },
-                .V128 => Val{ .V128 = instruction.immediate.ValueVec },
+                .V128 => blk: {
+                    const v: v128 = mir.module_def.v128_immediates.items[instruction.immediate.Index];
+                    break :blk Val{ .V128 = v };
+                },
                 else => @compileError("Unsupported const instruction"),
             };
 

--- a/src/vm_stack.zig
+++ b/src/vm_stack.zig
@@ -42,7 +42,6 @@ const ImportNames = def.ImportNames;
 const Instruction = def.Instruction;
 const Limits = def.Limits;
 const MemoryDefinition = def.MemoryDefinition;
-const MemoryOffsetAndLaneImmediates = def.MemoryOffsetAndLaneImmediates;
 const ModuleDefinition = def.ModuleDefinition;
 const NameCustomSection = def.NameCustomSection;
 const TableDefinition = def.TableDefinition;
@@ -3657,7 +3656,7 @@ pub const StackVM = struct {
             },
 
             Opcode.Call_Local => {
-                try preamble("Call", pc, code, stack);
+                try preamble("Call_Local", pc, code, stack);
 
                 const next = try OpHelpers.callLocal(pc, code, stack);
                 pc = next.continuation;
@@ -3666,7 +3665,7 @@ pub const StackVM = struct {
             },
 
             Opcode.Call_Import => {
-                try preamble("Call", pc, code, stack);
+                try preamble("Call_Import", pc, code, stack);
 
                 const next = try OpHelpers.callImport(pc, code, stack);
 


### PR DESCRIPTION
* Compressed if and block immediates to 8 bytes by moving the validation-only immediates to a separate struct that's only used during validation. Additionally, if continuations are now relative to the instruction index so they can be stored in a u16.
* Moved all other immediates to be stored in the module def and switched the runtime lookups to use an index into those arrays
* Instruction is now only 16 bytes instead of 32.