### PR TITLE
Use alignment when allocating vm and stack memory

### DIFF
--- a/src/Stack.zig
+++ b/src/Stack.zig
@@ -113,7 +113,8 @@ pub fn init(allocator: std.mem.Allocator) Stack {
 
 pub fn deinit(stack: *Stack) void {
     if (stack.mem.len > 0) {
-        stack.allocator.free(stack.mem);
+        const alignment = @max(@alignOf(StackVal), @alignOf(Label), @alignOf(CallFrame));
+        stack.allocator.rawFree(stack.mem, comptime std.mem.Alignment.fromByteUnits(alignment), @returnAddress());
     }
 }
 

--- a/src/Stack.zig
+++ b/src/Stack.zig
@@ -127,7 +127,7 @@ pub fn allocMemory(stack: *Stack, opts: AllocOpts) !void {
     const begin_labels = values_alloc_size;
     const begin_frames = values_alloc_size + labels_alloc_size;
 
-    stack.mem = try stack.allocator.alloc(u8, total_alloc_size);
+    stack.mem = try stack.allocator.alignedAlloc(u8, comptime std.mem.Alignment.fromByteUnits(alignment), total_alloc_size);
     stack.values.ptr = @as([*]StackVal, @alignCast(@ptrCast(stack.mem.ptr)));
     stack.values.len = opts.max_values;
     stack.labels.ptr = @as([*]Label, @alignCast(@ptrCast(stack.mem[begin_labels..].ptr)));

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -753,7 +753,7 @@ pub const VM = struct {
         const impl_alloc_size = std.mem.alignForward(usize, @sizeOf(T), alignment);
         const total_alloc_size = vm_alloc_size + impl_alloc_size;
 
-        var mem = try allocator.alloc(u8, total_alloc_size);
+        var mem = try allocator.alignedAlloc(u8, comptime std.mem.Alignment.fromByteUnits(alignment), total_alloc_size);
 
         var vm: *VM = @as(*VM, @ptrCast(@alignCast(mem.ptr)));
         const impl: *T = @as(*T, @ptrCast(@alignCast(mem[vm_alloc_size..].ptr)));

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -744,6 +744,7 @@ pub const VM = struct {
 
     allocator: std.mem.Allocator,
     mem: []u8, // VM and impl memory live here
+    mem_alignment: std.mem.Alignment, // alignment `mem` was allocated with, so it can be freed symmetrically
 
     impl: *anyopaque,
 
@@ -769,6 +770,7 @@ pub const VM = struct {
         vm.resolve_func_ref_fn = T.resolveFuncRef;
         vm.allocator = allocator;
         vm.mem = mem;
+        vm.mem_alignment = comptime std.mem.Alignment.fromByteUnits(alignment);
         vm.impl = impl;
 
         T.init(vm);
@@ -781,7 +783,8 @@ pub const VM = struct {
 
         var allocator = vm.allocator;
         const mem = vm.mem;
-        allocator.free(mem);
+        const alignment = vm.mem_alignment;
+        allocator.rawFree(mem, alignment, @returnAddress());
     }
 
     fn instantiate(vm: *VM, module: *ModuleInstance, opts: ModuleInstantiateOpts) InstantiateError!void {


### PR DESCRIPTION
The required alignment is already in scope, it's just currently unused in the allocation.

This switches to using `alignedAlloc` and passing in `alignment`.

(I ran into this when trying to use an allocator that doesn't always align to a big number regardless.)